### PR TITLE
H Series: offline programming, per-screen state, input signal tracking, direct actions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,6 @@ node_modules/
 package-lock.json
 .yarn
 .cursor
-pkg.tgz
 pkg/
+pkg.tgz
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -1,3 +1,50 @@
 # companion-module-novastar-splicer
 
+<<<<<<< Updated upstream
+=======
+Control module for Novastar H Series video wall processors (H2, H5, H9, H15, H20) via Bitfocus Companion.
+
+## Requirements
+
+- **Companion 4.3 or later** (uses preset template system and `@companion-module/base` 2.0.0)
+
+## Features
+
+- **22 actions** covering full H Series control: presets, brightness, freeze, FTB, PGM/PVW, take, source switching, test patterns, BKG, OSD, volume, blackout
+- **21 feedbacks** with both state-tracking and direct per-screen feedback types
+- **Real-time variables** for all screen states (brightness, freeze, FTB, BKG, OSD, test pattern)
+- **Offline programming mode** with configurable screen count (1-40) and input card count (1-40, 4 connectors each)
+- **Brightness template presets** using Companion 4.3's template system — 21 levels per screen (0-100% in 5% steps) with auto-save to hardware
+- **Optimistic state updates** — feedbacks and variables update immediately on action, with live state from processor when connected
+
+## Protocol
+
+Communicates via UDP on port 6000 using the Novastar H Series Control Protocol (V1.0.18/1.0.19).
+
+## Installation
+
+Install as a custom module in Companion 4.3+.
+
+## Upgrading from v3.0.2
+
+All existing action and feedback configurations are compatible. **Variable names have changed** from 0-based to 1-based numbering (e.g. `screenId_0` → `screen_1`). If you manually typed variable references in button text, you'll need to update them. See [HELP.md](./companion/HELP.md) for the full mapping.
+
+## Version History
+
+### 3.2.0
+- Add Set Brightness action (W0410) with absolute value 0-100
+- Add Save Brightness action (W0417) to save to LED hardware
+- Brightness template presets with feedback and 100ms save delay
+- Fix checkFeedbacks to specify feedback types
+- Fix updateEnhancedFromAction to push variable values immediately
+- Rename Screen FRZ to Freeze
+- Replace deprecated `required` with `requiredExpression`
+- Companion 4.3 minimum requirement
+
+### 3.1.0
+- Offline programming mode
+- Enhanced per-screen variables and direct feedbacks
+- Template preset system for presets and layers
+
+>>>>>>> Stashed changes
 See [HELP.md](./companion/HELP.md) and [LICENSE](./LICENSE)

--- a/companion/HELP.md
+++ b/companion/HELP.md
@@ -8,6 +8,7 @@ This module will allow you to control the splicer of Novastar.
 
 **Available actions:**
 
+<<<<<<< Updated upstream
 - Play Preset
 - Play Preset Group
 - Select Screen
@@ -28,3 +29,98 @@ This module will allow you to control the splicer of Novastar.
 - Turn on/off the OSD Text
 - Turn on/off the OSD Image
 - Turn on/off the BKG
+=======
+| Action | Description |
+|--------|-------------|
+| Select Screen | Select/deselect a screen for operations |
+| Select Layer | Select a layer on a screen |
+| Preset | Recall a preset for a screen |
+| Preset Group | Play a preset collection |
+| Set Brightness | Set absolute brightness (0-100) for a screen |
+| Save Brightness | Save current brightness to LED receiving card hardware |
+| Screen Brightness Add | Increase brightness by 1% |
+| Screen Brightness Minus | Decrease brightness by 1% |
+| Freeze | Enable/disable screen freeze |
+| Layer FRZ | Enable/disable layer freeze |
+| FTB | Enable/disable Fade to Black |
+| PGM/PVW | Switch between Program and Preview mode |
+| Take | Auto take with fade time |
+| Source | Switch input source on a layer |
+| Volume Switch | Enable/disable volume |
+| Screen Volume Add | Increase volume |
+| Screen Volume Minus | Decrease volume |
+| Test Pattern | Enable/disable test pattern on an output |
+| BKG | Enable/disable background |
+| OSD | Enable/disable OSD (text or image) |
+| Blackout | Enable/disable blackout on all screens |
+| Send Command | Send a custom UDP command |
+
+### Feedbacks
+
+| Feedback | Description |
+|----------|-------------|
+| Select Screen | Active when screen is selected |
+| Select Layer | Active when layer is selected |
+| Load Preset | Active when preset is loaded on a screen |
+| Preset Group Selection | Active when preset collection is selected |
+| PGM/PVW Status | Shows current PGM/PVW mode |
+| Take Status | Shows take state |
+| FTB Status | Active when FTB is enabled |
+| FTB (Direct) | Direct state check for FTB |
+| Freeze Screen | Active when screen is frozen |
+| Screen Frozen (Direct) | Direct state check for freeze |
+| Freeze Layer | Active when layer is frozen |
+| Brightness Match (Direct) | Active when screen brightness matches target value |
+| Input Source Selection | Active when input source matches |
+| Volume On/Off Status | Active when volume is enabled/disabled |
+| Test Pattern On/Off Status | Active when test pattern is active |
+| Test Pattern (Direct) | Direct state check for test pattern |
+| BKG Status | Active when background is enabled |
+| BKG (Direct) | Direct state check for BKG |
+| OSD Status | Active when OSD is enabled |
+| OSD Text (Direct) | Direct state check for OSD text |
+| OSD Image (Direct) | Direct state check for OSD image |
+
+### Variables
+
+**Per-screen variables** (where X is screen number, 1-based):
+
+| Variable | Description |
+|----------|-------------|
+| `screen_X` | Screen name |
+| `screen_X_brightness` | Current brightness (0-100) |
+| `screen_X_frozen` | Freeze state (On/Off) |
+| `screen_X_ftb` | FTB state (On/Off) |
+| `screen_X_bkg` | Background state (On/Off) |
+| `screen_X_osd_text` | OSD text state (On/Off) |
+| `screen_X_osd_image` | OSD image state (On/Off) |
+| `screen_X_test_pattern` | Test pattern state (On/Off) |
+| `screen_X_layer_Y` | Layer name |
+| `screen_X_preset_Y` | Preset name |
+
+**Other variables:**
+
+| Variable | Description |
+|----------|-------------|
+| `connection_state` | Online / Offline Programming / Disconnected |
+| `presetCollectionId_X` | Preset group name |
+| `source_X_Y` | Input source name |
+
+### Preset Templates
+
+Brightness level presets are generated using Companion 4.3's template system. Each screen gets a set of brightness buttons (100% down to 0% in 5% steps) that automatically set brightness and save to hardware with a 100ms delay. Feedback highlights the button matching current brightness.
+
+### Upgrading from v3.0.2
+
+All existing action and feedback configurations are compatible. **Variable names have changed** from 0-based to 1-based numbering. If you manually typed variable references in button text (not from presets), you will need to update them:
+
+| Old (v3.0.2) | New (v3.2) |
+|---|---|
+| `$(novastar-splicer:screenId_0)` | `$(novastar-splicer:screen_1)` |
+| `$(novastar-splicer:screenId_0_layerId_0)` | `$(novastar-splicer:screen_1_layer_1)` |
+| `$(novastar-splicer:screenId_0_presetId_0)` | `$(novastar-splicer:screen_1_preset_1)` |
+| `$(novastar-splicer:presetCollectionId_0)` | `$(novastar-splicer:presetCollectionId_1)` |
+| `$(novastar-splicer:source_0_255)` | `$(novastar-splicer:source_1_255)` |
+
+All numbering is now **1-based** (Screen 1, Layer 1, Preset 1). Buttons created from presets will update automatically — only manually-typed variable references need to be changed.
+>>>>>>> Stashed changes

--- a/package.json
+++ b/package.json
@@ -1,10 +1,11 @@
 {
 	"name": "novastar-splicer",
-	"version": "3.0.2",
+	"version": "3.1.0",
 	"main": "./src/main.js",
 	"type": "module",
 	"scripts": {
-		"format": "prettier -w ."
+		"format": "prettier -w .",
+		"build": "companion-module-build"
 	},
 	"license": "MIT",
 	"repository": {

--- a/src/actions.js
+++ b/src/actions.js
@@ -114,6 +114,7 @@ export const getActions = (instance) => {
         const [screenId, presetId] = combineId.split('_').map((item) => Number(item));
         instance.selectedPresetInfo = { screenId, presetId };
         instance.checkFeedbacks();
+        if (!instance.connectStatus) return;
         const command = handleParams(ACTIONS_CMD.load_preset, {
           screenId,
           presetId,
@@ -139,6 +140,7 @@ export const getActions = (instance) => {
         const {
           options: { command },
         } = event;
+        if (!instance.connectStatus) return;
         try {
           const params = Buffer.from(command);
           instance.udp.send(params);
@@ -165,6 +167,7 @@ export const getActions = (instance) => {
         const { presetCollectionId } = action.options;
         instance.selectedPresetCollectionId = presetCollectionId;
         instance.checkFeedbacks();
+        if (!instance.connectStatus) return;
         applyPresetCollection(instance, { presetCollectionId });
       },
     },
@@ -198,6 +201,7 @@ export const getActions = (instance) => {
           takeActive: false,
         };
         instance.checkFeedbacks();
+        if (!instance.connectStatus) return;
         instance.selectedScreenList?.forEach((_screenId) => {
           applyPgmOrPvw(instance, {
             enNonTime,
@@ -234,6 +238,7 @@ export const getActions = (instance) => {
         const { manualPlay } = action.options;
         instance.pgmOrPvwActive.takeActive = manualPlay === 1;
         instance.checkFeedbacks();
+        if (!instance.connectStatus) return;
         instance.selectedScreenList?.forEach((_screenId) => {
           applyPgmOrPvw(instance, {
             enNonTime: 1,
@@ -268,7 +273,12 @@ export const getActions = (instance) => {
       callback: async (action) => {
         const { type } = action.options;
         instance.ftb = !type;
+        // ENHANCED: Optimistic update for per-screen FTB
+        instance.selectedScreenList?.forEach((screenId) => {
+          instance.updateEnhancedFromAction(screenId, 'ftb', !type);
+        });
         instance.checkFeedbacks();
+        if (!instance.connectStatus) return;
         if (!instance.selectedScreenList?.length) return;
         const param = instance.selectedScreenList.map((screenId) => ({ type, screenId }));
         blackScreen(instance, param);
@@ -300,6 +310,7 @@ export const getActions = (instance) => {
         const { isMute } = action.options;
         instance.volumeMute = !isMute;
         instance.checkFeedbacks();
+        if (!instance.connectStatus) return;
         if (!instance.selectedScreenList?.length) return;
         const resList = [];
         //音量批量下发只生效一个，所以需要遍历下发
@@ -353,7 +364,12 @@ export const getActions = (instance) => {
         const { enable } = action.options;
         instance.log('debug', enable);
         instance.screenFRZState = enable;
+        // ENHANCED: Optimistic update for per-screen freeze
+        instance.selectedScreenList?.forEach((screenId) => {
+          instance.updateEnhancedFromAction(screenId, 'frozen', enable === 1);
+        });
         instance.checkFeedbacks();
+        if (!instance.connectStatus) return;
         if (instance.selectedScreenList.length === 0) {
           instance.log('error', 'Please select a screen');
           return;
@@ -368,6 +384,7 @@ export const getActions = (instance) => {
       name: 'Screen Volume Add',
       description: 'Increase the volume of the selected screen.',
       callback: () => {
+        if (!instance.connectStatus) return;
         instance.selectedScreenList?.forEach((screenId) => {
           const curScreenDetails = instance.screenList.find((screen) => screen.screenId === screenId)?.details;
           if (!curScreenDetails) return;
@@ -387,6 +404,7 @@ export const getActions = (instance) => {
       name: 'Screen Volume Minus',
       description: 'Decrease the volume of the selected screen.',
       callback: () => {
+        if (!instance.connectStatus) return;
         instance.selectedScreenList?.forEach((screenId) => {
           const curScreenDetails = instance.screenList.find((screen) => screen.screenId === Number(screenId))?.details;
           if (!curScreenDetails) return;
@@ -412,6 +430,9 @@ export const getActions = (instance) => {
           let brightness = curScreenDetails.brightness;
           brightness = Math.min(brightness + 1, 100);
           curScreenDetails.brightness = brightness;
+          // ENHANCED: Optimistic update for per-screen brightness
+          instance.updateEnhancedFromAction(screenId, 'brightness', brightness);
+          if (!instance.connectStatus) return;
           const command = handleParams(ACTIONS_CMD.apply_screen_brightness, {
             screenId,
             brightness: brightness,
@@ -430,6 +451,9 @@ export const getActions = (instance) => {
           let brightness = curScreenDetails.brightness;
           brightness = Math.max(brightness - 1, 0);
           curScreenDetails.brightness = brightness;
+          // ENHANCED: Optimistic update for per-screen brightness
+          instance.updateEnhancedFromAction(screenId, 'brightness', brightness);
+          if (!instance.connectStatus) return;
           const command = handleParams(ACTIONS_CMD.apply_screen_brightness, {
             screenId,
             brightness: brightness,
@@ -466,6 +490,7 @@ export const getActions = (instance) => {
         instance.log('debug', action.options);
         instance.layerFRZState = enable;
         instance.checkFeedbacks();
+        if (!instance.connectStatus) return;
         if (!instance.selectedLayerInfo) {
           instance.log('error', 'Please select a layer');
           return;
@@ -498,6 +523,7 @@ export const getActions = (instance) => {
         const source = instance.sourceList?.find((_item) => id === `${_item.inputId}_${_item.cropId}`);
         instance.selectedSourceId = id;
         instance.checkFeedbacks();
+        if (!instance.connectStatus) return;
         if (!source || !instance.selectedLayerInfo) return;
         instance.udp.send(
           handleParams(ACTIONS_CMD.source_switch, {
@@ -539,7 +565,12 @@ export const getActions = (instance) => {
       callback: async (action) => {
         const { testPattern } = action.options;
         instance.testPattern = testPattern === TEST_PATTERN_TYPE.OPEN;
+        // ENHANCED: Optimistic update for per-screen test pattern
+        instance.selectedScreenList?.forEach((screenId) => {
+          instance.updateEnhancedFromAction(screenId, 'testPattern', testPattern === TEST_PATTERN_TYPE.OPEN);
+        });
         instance.checkFeedbacks();
+        if (!instance.connectStatus) return;
         //目前的协议只支持遍历通过接口修改测试画面，后续协议支持按照屏幕修改后调整
         for (const screenId of instance.selectedScreenList) {
           const requests = [];
@@ -608,7 +639,12 @@ export const getActions = (instance) => {
       callback: (action) => {
         const { enable } = action.options;
         instance.bkgEnable = !!enable;
+        // ENHANCED: Optimistic update for per-screen BKG
+        instance.selectedScreenList?.forEach((screenId) => {
+          instance.updateEnhancedFromAction(screenId, 'bkg', !!enable);
+        });
         instance.checkFeedbacks();
+        if (!instance.connectStatus) return;
         if (!instance.selectedScreenList?.length) return;
         const requests = [];
         instance.selectedScreenList?.forEach((screenId) => {
@@ -679,7 +715,13 @@ export const getActions = (instance) => {
         } else {
           instance.textOsdEnable = !!enable;
         }
+        // ENHANCED: Optimistic update for per-screen OSD
+        const prop = osdType === 'image' ? 'osdImage' : 'osdText';
+        instance.selectedScreenList?.forEach((screenId) => {
+          instance.updateEnhancedFromAction(screenId, prop, !!enable);
+        });
         instance.checkFeedbacks();
+        if (!instance.connectStatus) return;
         if (!instance.selectedScreenList?.length) return;
         const requests = [];
         instance.selectedScreenList?.forEach((screenId) => {

--- a/src/actions.js
+++ b/src/actions.js
@@ -46,7 +46,7 @@ export const getActions = (instance) => {
         if (enable === 0) {
           instance.selectedScreenList = instance.selectedScreenList.filter((item) => item !== screenId);
         }
-        instance.checkFeedbacks();
+        instance.checkFeedbacks("screen_selected");
       },
     },
     // 选择图层
@@ -91,7 +91,7 @@ export const getActions = (instance) => {
         if (enable === 0) {
           instance.selectedLayerInfo = null;
         }
-        instance.checkFeedbacks();
+        instance.checkFeedbacks("layer_selected");
       },
     },
     // 加载场景
@@ -113,13 +113,13 @@ export const getActions = (instance) => {
         instance.log('debug', JSON.stringify(event.options));
         const [screenId, presetId] = combineId.split('_').map((item) => Number(item));
         instance.selectedPresetInfo = { screenId, presetId };
-        instance.checkFeedbacks();
+        instance.checkFeedbacks("preset_loaded");
         if (!instance.connectStatus) return;
         const command = handleParams(ACTIONS_CMD.load_preset, {
           screenId,
           presetId,
         });
-        instance.udp.send(command);
+        instance.safeSend(command);
       },
     },
     // 发送命令
@@ -143,7 +143,7 @@ export const getActions = (instance) => {
         if (!instance.connectStatus) return;
         try {
           const params = Buffer.from(command);
-          instance.udp.send(params);
+          instance.safeSend(params);
         } catch (error) {
           instance.log('error', 'send command error');
         }
@@ -166,7 +166,7 @@ export const getActions = (instance) => {
       callback: async (action) => {
         const { presetCollectionId } = action.options;
         instance.selectedPresetCollectionId = presetCollectionId;
-        instance.checkFeedbacks();
+        instance.checkFeedbacks("preset_group_selected");
         if (!instance.connectStatus) return;
         applyPresetCollection(instance, { presetCollectionId });
       },
@@ -200,7 +200,7 @@ export const getActions = (instance) => {
           pvwActive: !isPgm,
           takeActive: false,
         };
-        instance.checkFeedbacks();
+        instance.checkFeedbacks("pgm_pvw_switch");
         if (!instance.connectStatus) return;
         instance.selectedScreenList?.forEach((_screenId) => {
           applyPgmOrPvw(instance, {
@@ -237,7 +237,7 @@ export const getActions = (instance) => {
         if (!instance.pgmOrPvwActive.pvwActive) return;
         const { manualPlay } = action.options;
         instance.pgmOrPvwActive.takeActive = manualPlay === 1;
-        instance.checkFeedbacks();
+        instance.checkFeedbacks("pvw_take_selected");
         if (!instance.connectStatus) return;
         instance.selectedScreenList?.forEach((_screenId) => {
           applyPgmOrPvw(instance, {
@@ -277,7 +277,7 @@ export const getActions = (instance) => {
         instance.selectedScreenList?.forEach((screenId) => {
           instance.updateEnhancedFromAction(screenId, 'ftb', !type);
         });
-        instance.checkFeedbacks();
+        instance.checkFeedbacks("ftb_selected", "ftb_direct");
         if (!instance.connectStatus) return;
         if (!instance.selectedScreenList?.length) return;
         const param = instance.selectedScreenList.map((screenId) => ({ type, screenId }));
@@ -309,7 +309,7 @@ export const getActions = (instance) => {
       callback: async (action) => {
         const { isMute } = action.options;
         instance.volumeMute = !isMute;
-        instance.checkFeedbacks();
+        instance.checkFeedbacks("volume_switch_selected");
         if (!instance.connectStatus) return;
         if (!instance.selectedScreenList?.length) return;
         const resList = [];
@@ -339,13 +339,13 @@ export const getActions = (instance) => {
     },
     /** 屏幕冻结 */
     screen_frz_toggle: {
-      name: 'Screen FRZ',
+      name: 'Freeze',
       description: 'On/Off; freeze the selected screen.',
       options: [
         {
           type: 'dropdown',
-          name: 'Screen FRZ',
-          label: 'Screen FRZ',
+          name: 'Freeze',
+          label: 'Freeze',
           id: 'enable',
           default: 1,
           choices: [
@@ -368,7 +368,7 @@ export const getActions = (instance) => {
         instance.selectedScreenList?.forEach((screenId) => {
           instance.updateEnhancedFromAction(screenId, 'frozen', enable === 1);
         });
-        instance.checkFeedbacks();
+        instance.checkFeedbacks("screen_frz", "frozen_direct");
         if (!instance.connectStatus) return;
         if (instance.selectedScreenList.length === 0) {
           instance.log('error', 'Please select a screen');
@@ -376,7 +376,7 @@ export const getActions = (instance) => {
         }
         instance.selectedScreenList.forEach((screenId) => {
           instance.log('debug', { screenId, enable });
-          instance.udp.send(handleParams(ACTIONS_CMD.screen_frz, { screenId, enable }));
+          instance.safeSend(handleParams(ACTIONS_CMD.screen_frz, { screenId, enable }));
         });
       },
     },
@@ -396,7 +396,7 @@ export const getActions = (instance) => {
             volume: volume,
             isMute: 0,
           });
-          instance.udp.send(command);
+          instance.safeSend(command);
         });
       },
     },
@@ -416,7 +416,7 @@ export const getActions = (instance) => {
             volume: volume,
             isMute: 0,
           });
-          instance.udp.send(command);
+          instance.safeSend(command);
         });
       },
     },
@@ -437,7 +437,7 @@ export const getActions = (instance) => {
             screenId,
             brightness: brightness,
           });
-          instance.udp.send(command);
+          instance.safeSend(command);
         });
       },
     },
@@ -458,8 +458,206 @@ export const getActions = (instance) => {
             screenId,
             brightness: brightness,
           });
-          instance.udp.send(command);
+          instance.safeSend(command);
         });
+      },
+    },
+    // Set absolute brightness (W0410)
+    set_brightness: {
+      name: 'Set Brightness',
+      description: 'Set the brightness of the selected screen to an absolute value (0-100).',
+      options: [
+        {
+          type: 'dropdown',
+          name: 'Screen',
+          label: 'Screen',
+          id: 'screenId',
+          default: screenListDropDown[0]?.id ?? null,
+          choices: screenListDropDown,
+        },
+        {
+          type: 'textinput',
+          name: 'Brightness (0-100)',
+          label: 'Brightness (0-100)',
+          id: 'brightness',
+          default: '100',
+          useVariables: true,
+        },
+      ],
+      callback: async (event) => {
+        const screenId = event.options.screenId;
+        const brightnessRaw = String(event.options.brightness);
+        const brightness = Math.max(0, Math.min(100, Math.round(Number(brightnessRaw))));
+        if (isNaN(brightness)) {
+          instance.log('warn', `set_brightness: invalid brightness value "${event.options.brightness}"`);
+          return;
+        }
+        const curScreenDetails = instance.screenList?.find((screen) => screen.screenId === screenId)?.details;
+        if (curScreenDetails) {
+          curScreenDetails.brightness = brightness;
+        }
+        instance.updateEnhancedFromAction(screenId, 'brightness', brightness);
+        if (!instance.connectStatus) return;
+        const command = handleParams(ACTIONS_CMD.apply_screen_brightness, {
+          screenId,
+          brightness,
+        });
+        instance.safeSend(command);
+      },
+    },
+    // Save current brightness to LED receiving card hardware (W0417)
+    save_brightness: {
+      name: 'Save Brightness',
+      description: 'Save the current screen brightness to the LED receiving card hardware.',
+      options: [
+        {
+          type: 'dropdown',
+          name: 'Screen',
+          label: 'Screen',
+          id: 'screenId',
+          default: screenListDropDown[0]?.id ?? null,
+          choices: screenListDropDown,
+        },
+      ],
+      callback: (event) => {
+        const screenId = event.options.screenId;
+        if (!instance.connectStatus) return;
+        const command = handleParams(ACTIONS_CMD.save_screen_brightness, {
+          screenId,
+        });
+        instance.safeSend(command);
+      },
+    },
+    // ==================== Direct per-screen actions ====================
+    // Direct Freeze (W040A) - per screen
+    freeze_direct: {
+      name: 'Freeze (Direct)',
+      description: 'Enable or disable freeze on a specific screen.',
+      options: [
+        {
+          type: 'dropdown',
+          label: 'Screen',
+          id: 'screenId',
+          default: screenListDropDown[0]?.id ?? null,
+          choices: screenListDropDown,
+        },
+        {
+          type: 'dropdown',
+          label: 'State',
+          id: 'state',
+          default: 1,
+          choices: [
+            { id: 1, label: 'Enable' },
+            { id: 0, label: 'Disable' },
+          ],
+        },
+      ],
+      callback: async (event) => {
+        const screenId = event.options.screenId;
+        const state = parseInt(event.options.state);
+        instance.updateEnhancedFromAction(screenId, 'frozen', state === 1);
+        if (!instance.connectStatus) return;
+        instance.safeSend(handleParams(ACTIONS_CMD.screen_frz, { screenId, enable: state }));
+      },
+    },
+    // Direct FTB (W0409) - per screen
+    ftb_direct: {
+      name: 'FTB (Direct)',
+      description: 'Enable or disable Fade to Black on a specific screen.',
+      options: [
+        {
+          type: 'dropdown',
+          label: 'Screen',
+          id: 'screenId',
+          default: screenListDropDown[0]?.id ?? null,
+          choices: screenListDropDown,
+        },
+        {
+          type: 'dropdown',
+          label: 'State',
+          id: 'state',
+          default: 1,
+          choices: [
+            { id: 1, label: 'Enable' },
+            { id: 0, label: 'Disable' },
+          ],
+        },
+      ],
+      callback: async (event) => {
+        const screenId = event.options.screenId;
+        const state = parseInt(event.options.state);
+        instance.updateEnhancedFromAction(screenId, 'ftb', state === 1);
+        if (!instance.connectStatus) return;
+        const command = handleParams(ACTIONS_CMD.black_screen, {
+          screenId,
+          type: state === 1 ? 0 : 1,
+        });
+        instance.safeSend(command);
+      },
+    },
+    // Direct BKG (W040B) - per screen
+    bkg_direct: {
+      name: 'BKG (Direct)',
+      description: 'Enable or disable background on a specific screen.',
+      options: [
+        {
+          type: 'dropdown',
+          label: 'Screen',
+          id: 'screenId',
+          default: screenListDropDown[0]?.id ?? null,
+          choices: screenListDropDown,
+        },
+        {
+          type: 'dropdown',
+          label: 'State',
+          id: 'state',
+          default: 1,
+          choices: [
+            { id: 1, label: 'Enable' },
+            { id: 0, label: 'Disable' },
+          ],
+        },
+      ],
+      callback: async (event) => {
+        const screenId = event.options.screenId;
+        const state = parseInt(event.options.state);
+        instance.updateEnhancedFromAction(screenId, 'bkg', state === 1);
+        if (!instance.connectStatus) return;
+        const params = { screenId, enable: state, bkgId: 0 };
+        instance.safeSend(handleParams(ACTIONS_CMD.bkg_switch, params));
+      },
+    },
+    // Direct OSD (W040C) - per screen
+    osd_direct: {
+      name: 'OSD (Direct)',
+      description: 'Enable or disable OSD on a specific screen.',
+      options: [
+        {
+          type: 'dropdown',
+          label: 'Screen',
+          id: 'screenId',
+          default: screenListDropDown[0]?.id ?? null,
+          choices: screenListDropDown,
+        },
+        {
+          type: 'dropdown',
+          label: 'State',
+          id: 'state',
+          default: 1,
+          choices: [
+            { id: 1, label: 'Enable' },
+            { id: 0, label: 'Disable' },
+          ],
+        },
+      ],
+      callback: async (event) => {
+        const screenId = event.options.screenId;
+        const state = parseInt(event.options.state);
+        instance.updateEnhancedFromAction(screenId, 'osdText', state === 1);
+        instance.updateEnhancedFromAction(screenId, 'osdImage', state === 1);
+        if (!instance.connectStatus) return;
+        const params = { screenId, Osd: { enable: state } };
+        instance.safeSend(handleParams(ACTIONS_CMD.osd_switch, params));
       },
     },
     /** 图层冻结 */
@@ -489,13 +687,13 @@ export const getActions = (instance) => {
         const { enable } = action.options;
         instance.log('debug', action.options);
         instance.layerFRZState = enable;
-        instance.checkFeedbacks();
+        instance.checkFeedbacks("layer_frz");
         if (!instance.connectStatus) return;
         if (!instance.selectedLayerInfo) {
           instance.log('error', 'Please select a layer');
           return;
         }
-        instance.udp.send(
+        instance.safeSend(
           handleParams(ACTIONS_CMD.layer_frz, {
             layerId: instance.selectedLayerInfo.layerId,
             screenId: instance.selectedLayerInfo.screenId,
@@ -522,10 +720,10 @@ export const getActions = (instance) => {
         const { id } = action.options;
         const source = instance.sourceList?.find((_item) => id === `${_item.inputId}_${_item.cropId}`);
         instance.selectedSourceId = id;
-        instance.checkFeedbacks();
+        instance.checkFeedbacks("source_switch_selected");
         if (!instance.connectStatus) return;
         if (!source || !instance.selectedLayerInfo) return;
-        instance.udp.send(
+        instance.safeSend(
           handleParams(ACTIONS_CMD.source_switch, {
             inputId: source.inputId,
             sourceType: source.sourceType,
@@ -569,7 +767,7 @@ export const getActions = (instance) => {
         instance.selectedScreenList?.forEach((screenId) => {
           instance.updateEnhancedFromAction(screenId, 'testPattern', testPattern === TEST_PATTERN_TYPE.OPEN);
         });
-        instance.checkFeedbacks();
+        instance.checkFeedbacks("test_pattern_selected", "test_pattern_direct");
         if (!instance.connectStatus) return;
         //目前的协议只支持遍历通过接口修改测试画面，后续协议支持按照屏幕修改后调整
         for (const screenId of instance.selectedScreenList) {
@@ -643,7 +841,7 @@ export const getActions = (instance) => {
         instance.selectedScreenList?.forEach((screenId) => {
           instance.updateEnhancedFromAction(screenId, 'bkg', !!enable);
         });
-        instance.checkFeedbacks();
+        instance.checkFeedbacks("bkg_switch", "bkg_direct");
         if (!instance.connectStatus) return;
         if (!instance.selectedScreenList?.length) return;
         const requests = [];
@@ -720,7 +918,7 @@ export const getActions = (instance) => {
         instance.selectedScreenList?.forEach((screenId) => {
           instance.updateEnhancedFromAction(screenId, prop, !!enable);
         });
-        instance.checkFeedbacks();
+        instance.checkFeedbacks("osd_switch", "osd_text_direct", "osd_image_direct");
         if (!instance.connectStatus) return;
         if (!instance.selectedScreenList?.length) return;
         const requests = [];
@@ -744,6 +942,32 @@ export const getActions = (instance) => {
           );
         });
         sendUDPRequestsSync(instance, requests);
+      },
+    },
+    // Global blackout on all screens (W0700)
+    blackout: {
+      name: 'Blackout',
+      description: 'Enable or disable blackout on all screens.',
+      options: [
+        {
+          type: 'dropdown',
+          name: 'State',
+          label: 'State',
+          id: 'state',
+          default: 1,
+          choices: [
+            { id: 1, label: 'Enable' },
+            { id: 0, label: 'Disable' },
+          ],
+        },
+      ],
+      callback: (event) => {
+        const state = parseInt(event.options.state);
+        if (!instance.connectStatus) return;
+        const command = handleParams(ACTIONS_CMD.blackout, {
+          blackout: state,
+        });
+        instance.safeSend(command);
       },
     },
   };

--- a/src/actions.js
+++ b/src/actions.js
@@ -529,6 +529,56 @@ export const getActions = (instance) => {
       },
     },
     // ==================== Direct per-screen actions ====================
+    // Direct Brightness Increase - per screen
+    brightness_add_direct: {
+      name: 'Brightness + (Direct)',
+      description: 'Increase brightness by 1% on a specific screen.',
+      options: [
+        {
+          type: 'dropdown',
+          label: 'Screen',
+          id: 'screenId',
+          default: screenListDropDown[0]?.id ?? null,
+          choices: screenListDropDown,
+        },
+      ],
+      callback: async (event) => {
+        const screenId = event.options.screenId;
+        const curScreenDetails = instance.screenList?.find((screen) => screen.screenId === screenId)?.details;
+        if (!curScreenDetails) return;
+        const brightness = Math.min(curScreenDetails.brightness + 1, 100);
+        curScreenDetails.brightness = brightness;
+        instance.updateEnhancedFromAction(screenId, 'brightness', brightness);
+        if (!instance.connectStatus) return;
+        const command = handleParams(ACTIONS_CMD.apply_screen_brightness, { screenId, brightness });
+        instance.safeSend(command);
+      },
+    },
+    // Direct Brightness Decrease - per screen
+    brightness_minus_direct: {
+      name: 'Brightness - (Direct)',
+      description: 'Decrease brightness by 1% on a specific screen.',
+      options: [
+        {
+          type: 'dropdown',
+          label: 'Screen',
+          id: 'screenId',
+          default: screenListDropDown[0]?.id ?? null,
+          choices: screenListDropDown,
+        },
+      ],
+      callback: async (event) => {
+        const screenId = event.options.screenId;
+        const curScreenDetails = instance.screenList?.find((screen) => screen.screenId === screenId)?.details;
+        if (!curScreenDetails) return;
+        const brightness = Math.max(curScreenDetails.brightness - 1, 0);
+        curScreenDetails.brightness = brightness;
+        instance.updateEnhancedFromAction(screenId, 'brightness', brightness);
+        if (!instance.connectStatus) return;
+        const command = handleParams(ACTIONS_CMD.apply_screen_brightness, { screenId, brightness });
+        instance.safeSend(command);
+      },
+    },
     // Direct Freeze (W040A) - per screen
     freeze_direct: {
       name: 'Freeze (Direct)',

--- a/src/feedbacks.js
+++ b/src/feedbacks.js
@@ -339,17 +339,16 @@ export const getFeedbacks = (instance) => {
           choices: screenChoices,
         },
         {
-          type: 'number',
-          label: 'Brightness',
+          type: 'textinput',
+          label: 'Brightness (0-100)',
           id: 'brightness',
-          default: 100,
-          min: 0,
-          max: 100,
+          default: '100',
+          useVariables: true,
         },
       ],
       callback: (event) => {
         const state = instance.enhancedState.screens[event.options.screenId];
-        return state ? state.brightness === event.options.brightness : false;
+        return state ? Number(state.brightness) === Number(event.options.brightness) : false;
       },
     },
     test_pattern_direct: {

--- a/src/feedbacks.js
+++ b/src/feedbacks.js
@@ -373,5 +373,38 @@ export const getFeedbacks = (instance) => {
         return state ? state.testPattern : false;
       },
     },
+    input_signal: {
+      type: 'boolean',
+      name: 'Input Signal Active',
+      description: 'True when an input has an active signal.',
+      defaultStyle: {
+        bgcolor: combineRgb(0, 200, 0),
+        color: combineRgb(255, 255, 255),
+      },
+      options: [
+        {
+          type: 'dropdown',
+          label: 'Input',
+          id: 'inputKey',
+          default: 'input_1_1',
+          choices: (() => {
+            const choices = [];
+            const inputCardCount = instance.config?.inputCardCount || 1;
+            for (let slot = 0; slot < inputCardCount; slot++) {
+              for (let conn = 0; conn < 4; conn++) {
+                choices.push({
+                  id: `input_${slot + 1}_${conn + 1}`,
+                  label: `Input ${slot + 1}-${conn + 1}`,
+                });
+              }
+            }
+            return choices;
+          })(),
+        },
+      ],
+      callback: (event) => {
+        return instance.inputSignalState[event.options.inputKey] === true;
+      },
+    },
   };
 };

--- a/src/feedbacks.js
+++ b/src/feedbacks.js
@@ -5,7 +5,15 @@ import formatDropDownData from '../utils/formatDropDown.js';
 export const getFeedbacks = (instance) => {
   const { presetCollectionListDropDown, sourceListDropDown, presetDropDown, screenListDropDown, layerListDropDown } =
     formatDropDownData(instance);
+
+  // ENHANCED: Build screen choices for direct feedbacks from live screenList
+  const screenChoices = instance.screenList?.map((s) => ({
+    id: s.screenId,
+    label: s.name,
+  })) || [];
+
   return {
+    // ==================== ORIGINAL v3.0.2 FEEDBACKS ====================
     screen_selected: {
       type: 'boolean',
       name: 'Select Screen',
@@ -199,6 +207,171 @@ export const getFeedbacks = (instance) => {
           instance.selectedPresetInfo.screenId === screenId &&
           instance.selectedPresetInfo.presetId === presetId
         );
+      },
+    },
+
+    // ==================== ENHANCED: Direct per-screen feedbacks ====================
+
+    frozen_direct: {
+      type: 'boolean',
+      name: 'Screen Frozen (Direct)',
+      description: 'Shows frozen state for a specific screen without requiring screen selection.',
+      defaultStyle: {
+        bgcolor: combineRgb(0, 0, 255),
+        color: combineRgb(255, 255, 255),
+      },
+      options: [
+        {
+          type: 'dropdown',
+          label: 'Screen',
+          id: 'screenId',
+          default: screenChoices[0]?.id ?? 0,
+          choices: screenChoices,
+        },
+      ],
+      callback: (event) => {
+        const state = instance.enhancedState.screens[event.options.screenId];
+        return state ? state.frozen : false;
+      },
+    },
+    ftb_direct: {
+      type: 'boolean',
+      name: 'FTB (Direct)',
+      description: 'Shows FTB state for a specific screen without requiring screen selection.',
+      defaultStyle: {
+        bgcolor: combineRgb(255, 0, 0),
+        color: combineRgb(255, 255, 255),
+      },
+      options: [
+        {
+          type: 'dropdown',
+          label: 'Screen',
+          id: 'screenId',
+          default: screenChoices[0]?.id ?? 0,
+          choices: screenChoices,
+        },
+      ],
+      callback: (event) => {
+        const state = instance.enhancedState.screens[event.options.screenId];
+        return state ? state.ftb : false;
+      },
+    },
+    bkg_direct: {
+      type: 'boolean',
+      name: 'BKG (Direct)',
+      description: 'Shows BKG state for a specific screen without requiring screen selection.',
+      defaultStyle: {
+        bgcolor: combineRgb(0, 255, 0),
+        color: combineRgb(0, 0, 0),
+      },
+      options: [
+        {
+          type: 'dropdown',
+          label: 'Screen',
+          id: 'screenId',
+          default: screenChoices[0]?.id ?? 0,
+          choices: screenChoices,
+        },
+      ],
+      callback: (event) => {
+        const state = instance.enhancedState.screens[event.options.screenId];
+        return state ? state.bkg : false;
+      },
+    },
+    osd_text_direct: {
+      type: 'boolean',
+      name: 'OSD Text (Direct)',
+      description: 'Shows OSD Text state for a specific screen without requiring screen selection.',
+      defaultStyle: {
+        bgcolor: combineRgb(0, 255, 0),
+        color: combineRgb(0, 0, 0),
+      },
+      options: [
+        {
+          type: 'dropdown',
+          label: 'Screen',
+          id: 'screenId',
+          default: screenChoices[0]?.id ?? 0,
+          choices: screenChoices,
+        },
+      ],
+      callback: (event) => {
+        const state = instance.enhancedState.screens[event.options.screenId];
+        return state ? state.osdText : false;
+      },
+    },
+    osd_image_direct: {
+      type: 'boolean',
+      name: 'OSD Image (Direct)',
+      description: 'Shows OSD Image state for a specific screen without requiring screen selection.',
+      defaultStyle: {
+        bgcolor: combineRgb(0, 255, 0),
+        color: combineRgb(0, 0, 0),
+      },
+      options: [
+        {
+          type: 'dropdown',
+          label: 'Screen',
+          id: 'screenId',
+          default: screenChoices[0]?.id ?? 0,
+          choices: screenChoices,
+        },
+      ],
+      callback: (event) => {
+        const state = instance.enhancedState.screens[event.options.screenId];
+        return state ? state.osdImage : false;
+      },
+    },
+    brightness_match: {
+      type: 'boolean',
+      name: 'Brightness Match (Direct)',
+      description: 'True when a specific screen brightness matches the target value.',
+      defaultStyle: {
+        bgcolor: combineRgb(255, 255, 0),
+        color: combineRgb(0, 0, 0),
+      },
+      options: [
+        {
+          type: 'dropdown',
+          label: 'Screen',
+          id: 'screenId',
+          default: screenChoices[0]?.id ?? 0,
+          choices: screenChoices,
+        },
+        {
+          type: 'number',
+          label: 'Brightness',
+          id: 'brightness',
+          default: 100,
+          min: 0,
+          max: 100,
+        },
+      ],
+      callback: (event) => {
+        const state = instance.enhancedState.screens[event.options.screenId];
+        return state ? state.brightness === event.options.brightness : false;
+      },
+    },
+    test_pattern_direct: {
+      type: 'boolean',
+      name: 'Test Pattern (Direct)',
+      description: 'Shows test pattern state for a specific screen without requiring screen selection.',
+      defaultStyle: {
+        bgcolor: combineRgb(0, 255, 0),
+        color: combineRgb(0, 0, 0),
+      },
+      options: [
+        {
+          type: 'dropdown',
+          label: 'Screen',
+          id: 'screenId',
+          default: screenChoices[0]?.id ?? 0,
+          choices: screenChoices,
+        },
+      ],
+      callback: (event) => {
+        const state = instance.enhancedState.screens[event.options.screenId];
+        return state ? state.testPattern : false;
       },
     },
   };

--- a/src/main.js
+++ b/src/main.js
@@ -91,6 +91,27 @@ class ModuleInstance extends InstanceBase {
     };
   }
 
+  // ========== Safe UDP send wrapper ==========
+
+  /** Send data via UDP with error handling to prevent crashes */
+  safeSend(data) {
+    if (!this.udp) {
+      this.log('debug', 'safeSend: no UDP socket');
+      return;
+    }
+    try {
+      this.udp.send(data);
+    } catch (err) {
+      this.log('warn', `UDP send error: ${err.message}`);
+      this.connectStatus = false;
+      if (this.config.offlineMode) {
+        this.updateStatus(InstanceStatus.Ok, 'Offline Programming Mode');
+      } else {
+        this.updateStatus(InstanceStatus.ConnectionFailure);
+      }
+    }
+  }
+
   // ========== ENHANCED: Per-screen state management ==========
 
   /** Initialize enhanced state for a screen with defaults */
@@ -127,7 +148,22 @@ class ModuleInstance extends InstanceBase {
       this.initEnhancedScreen(screenId);
     }
     this.enhancedState.screens[screenId][property] = value;
-    this.checkFeedbacks();
+
+    // Push updated variable value to Companion immediately
+    const prefix = `screen_${screenId + 1}`;
+    const varMap = {
+      brightness: { key: `${prefix}_brightness`, val: value, feedbacks: ['brightness_match'] },
+      frozen: { key: `${prefix}_frozen`, val: value ? 'On' : 'Off', feedbacks: ['frozen_direct', 'screen_frz'] },
+      ftb: { key: `${prefix}_ftb`, val: value ? 'On' : 'Off', feedbacks: ['ftb_direct', 'ftb_selected'] },
+      bkg: { key: `${prefix}_bkg`, val: value ? 'On' : 'Off', feedbacks: ['bkg_direct', 'bkg_switch'] },
+      osdText: { key: `${prefix}_osd_text`, val: value ? 'On' : 'Off', feedbacks: ['osd_text_direct', 'osd_switch'] },
+      osdImage: { key: `${prefix}_osd_image`, val: value ? 'On' : 'Off', feedbacks: ['osd_image_direct', 'osd_switch'] },
+      testPattern: { key: `${prefix}_test_pattern`, val: value ? 'On' : 'Off', feedbacks: ['test_pattern_direct', 'test_pattern_selected'] },
+    };
+    if (varMap[property]) {
+      this.setVariableValues({ [varMap[property].key]: varMap[property].val });
+      this.checkFeedbacks(...varMap[property].feedbacks);
+    }
   }
 
   /** Generate per-screen enhanced variables */
@@ -259,14 +295,21 @@ class ModuleInstance extends InstanceBase {
     this.generateOfflineData();
     this.updateAll();
 
+    // Offline Programming Mode — set OK immediately so variables and feedbacks work
+    if (this.config.offlineMode) {
+      this.log('info', 'Offline Programming Mode enabled');
+      this.updateStatus(InstanceStatus.Ok, 'Offline Programming Mode');
+    }
+
     // If host is configured, attempt connection
     if (this.config.host) {
-      this.updateStatus(InstanceStatus.Connecting);
+      if (!this.config.offlineMode) {
+        this.updateStatus(InstanceStatus.Connecting);
+      }
       this.initUDP();
-    } else {
-      // No host = offline mode, status Ok for programming
-      this.log('info', 'No host configured — running in offline mode for programming');
-      this.updateStatus(InstanceStatus.Ok, 'Offline');
+    } else if (!this.config.offlineMode) {
+      this.log('info', 'No host configured');
+      this.updateStatus(InstanceStatus.Disconnected, 'No host configured');
     }
   }
 
@@ -365,9 +408,24 @@ class ModuleInstance extends InstanceBase {
       // Device size configuration (always available for offline programming)
       {
         type: 'static-text',
+        id: 'offline_heading',
+        width: 12,
+        label: 'Offline Programming',
+        value: 'Enable Offline Programming Mode to activate variables and feedbacks without a device connection. This allows full pre-programming of your show before equipment arrives on-site.',
+      },
+      {
+        type: 'checkbox',
+        id: 'offlineMode',
+        label: 'Enable Offline Programming Mode',
+        width: 6,
+        default: false,
+        tooltip: 'When enabled, the module will report as connected (OK) even without a device, allowing variables and feedbacks to function for offline programming.',
+      },
+      {
+        type: 'static-text',
         id: 'offline_info',
         width: 12,
-        label: 'Information',
+        label: 'Device Configuration',
         value: 'The counts below will automatically populate from the device upon connection, however, they can be set manually for offline programming.',
       },
       {
@@ -507,6 +565,7 @@ class ModuleInstance extends InstanceBase {
     const hasHost = !!config.host;
     const hostChanged = this.config.host !== config.host;
     const sizeChanged = this.config.screenCount !== config.screenCount || this.config.inputCardCount !== config.inputCardCount;
+    const offlineModeChanged = this.config.offlineMode !== config.offlineMode;
 
     this.log('info', 'configUpdated module....');
 
@@ -520,6 +579,20 @@ class ModuleInstance extends InstanceBase {
       this.enhancedState = { screens: {} };
       this.generateOfflineData();
       this.updateAll();
+    }
+
+    // If offline mode toggled, update status immediately
+    if (offlineModeChanged) {
+      if (this.config.offlineMode) {
+        this.updateStatus(InstanceStatus.Ok, 'Offline Programming Mode');
+        this.updateAll();
+      } else if (!this.connectStatus) {
+        if (hasHost) {
+          this.updateStatus(InstanceStatus.Connecting);
+        } else {
+          this.updateStatus(InstanceStatus.Disconnected, 'No host configured');
+        }
+      }
     }
 
     // No host = stay in offline mode
@@ -536,7 +609,11 @@ class ModuleInstance extends InstanceBase {
       this.heartbeatManager.stop();
       this.clearInitStatusTimer();
       this.connectStatus = false;
-      this.updateStatus(InstanceStatus.Ok, 'Offline');
+      if (this.config.offlineMode) {
+        this.updateStatus(InstanceStatus.Ok, 'Offline Programming Mode');
+      } else {
+        this.updateStatus(InstanceStatus.Disconnected, 'No host configured');
+      }
       return;
     }
 
@@ -566,7 +643,7 @@ class ModuleInstance extends InstanceBase {
   sendInitStatusRequest() {
     this.log('debug', 'Sending initial status request...');
     if (this.udp) {
-      this.udp.send(Buffer.from(JSON.stringify([{ cmd: ACTIONS_CMD.get_device_init_status, param0: this.deviceId }])));
+      this.safeSend(Buffer.from(JSON.stringify([{ cmd: ACTIONS_CMD.get_device_init_status, param0: this.deviceId }])));
     }
   }
 
@@ -597,7 +674,7 @@ class ModuleInstance extends InstanceBase {
 
   sendHeartbeat() {
     if (this.udp) {
-      this.udp.send(Buffer.from(JSON.stringify([{ cmd: ACTIONS_CMD.device_heartbeat, deviceId: this.deviceId }])));
+      this.safeSend(Buffer.from(JSON.stringify([{ cmd: ACTIONS_CMD.device_heartbeat, deviceId: this.deviceId }])));
     }
   }
 

--- a/src/main.js
+++ b/src/main.js
@@ -84,7 +84,158 @@ class ModuleInstance extends InstanceBase {
     });
     /** 加载的场景信息 */
     this.selectedPresetInfo = null;
+
+    // ========== ENHANCED: Per-screen direct state ==========
+    this.enhancedState = {
+      screens: {},
+    };
   }
+
+  // ========== ENHANCED: Per-screen state management ==========
+
+  /** Initialize enhanced state for a screen with defaults */
+  initEnhancedScreen(screenId) {
+    this.enhancedState.screens[screenId] = {
+      frozen: false,
+      ftb: false,
+      bkg: false,
+      osdText: false,
+      osdImage: false,
+      brightness: 100,
+      testPattern: false,
+    };
+  }
+
+  /** Update enhanced state from R0401 screen details response */
+  updateEnhancedFromDetails(screenId, details) {
+    if (!this.enhancedState.screens[screenId]) {
+      this.initEnhancedScreen(screenId);
+    }
+    const state = this.enhancedState.screens[screenId];
+    if (details.brightness !== undefined) state.brightness = details.brightness;
+    if (details.screenFrz !== undefined) state.frozen = details.screenFrz === 1;
+    // FTB inverted logic: blackout 0 = FTB enabled, 1 = FTB disabled
+    if (details.blackout !== undefined) state.ftb = details.blackout === 0;
+    if (details.bkgEnable !== undefined) state.bkg = details.bkgEnable === 1;
+    if (details.textOsdEnable !== undefined) state.osdText = details.textOsdEnable === 1;
+    if (details.imgOsdEnable !== undefined) state.osdImage = details.imgOsdEnable === 1;
+  }
+
+  /** Optimistic update from action callback for instant feedback */
+  updateEnhancedFromAction(screenId, property, value) {
+    if (!this.enhancedState.screens[screenId]) {
+      this.initEnhancedScreen(screenId);
+    }
+    this.enhancedState.screens[screenId][property] = value;
+    this.checkFeedbacks();
+  }
+
+  /** Generate per-screen enhanced variables */
+  getEnhancedVariables() {
+    const definitions = [];
+    const values = {};
+
+    for (const [screenIdStr, state] of Object.entries(this.enhancedState.screens)) {
+      const screenId = Number(screenIdStr);
+      const screen = this.screenList.find((s) => s.screenId === screenId);
+      const screenName = screen ? screen.name : `Screen ${screenId + 1}`;
+      const prefix = `screen_${screenId + 1}`;
+
+      definitions.push(
+        { variableId: `${prefix}_brightness`, name: `${screenName} Brightness` },
+        { variableId: `${prefix}_frozen`, name: `${screenName} Frozen` },
+        { variableId: `${prefix}_ftb`, name: `${screenName} FTB` },
+        { variableId: `${prefix}_bkg`, name: `${screenName} BKG` },
+        { variableId: `${prefix}_osd_text`, name: `${screenName} OSD Text` },
+        { variableId: `${prefix}_osd_image`, name: `${screenName} OSD Image` },
+        { variableId: `${prefix}_test_pattern`, name: `${screenName} Test Pattern` },
+      );
+
+      values[`${prefix}_brightness`] = state.brightness;
+      values[`${prefix}_frozen`] = state.frozen ? 'On' : 'Off';
+      values[`${prefix}_ftb`] = state.ftb ? 'On' : 'Off';
+      values[`${prefix}_bkg`] = state.bkg ? 'On' : 'Off';
+      values[`${prefix}_osd_text`] = state.osdText ? 'On' : 'Off';
+      values[`${prefix}_osd_image`] = state.osdImage ? 'On' : 'Off';
+      values[`${prefix}_test_pattern`] = state.testPattern ? 'On' : 'Off';
+    }
+
+    return { definitions, values };
+  }
+
+  // ========== ENHANCED: Offline mode data generation ==========
+
+  generateOfflineData() {
+    const screenCount = this.config.screenCount || 4;
+    const inputCardCount = this.config.inputCardCount || 10;
+    const PRESETS_PER_SCREEN = 20;
+
+    // Generate screenList matching the format from R0400/R0500/R0600
+    this.screenList = [];
+    for (let i = 0; i < screenCount; i++) {
+      const screen = {
+        screenId: i,
+        name: `Screen ${i + 1}`,
+        layers: [
+          { layerId: 0, name: 'Layer 1' },
+          { layerId: 1, name: 'Layer 2' },
+          { layerId: 2, name: 'Layer 3' },
+          { layerId: 3, name: 'Layer 4' },
+        ],
+        presets: [],
+        details: {
+          screenId: i,
+          brightness: 100,
+          screenFrz: 0,
+          blackout: 1, // 1 = not blacked out (FTB inverted logic)
+          bkgEnable: 0,
+          textOsdEnable: 0,
+          imgOsdEnable: 0,
+        },
+      };
+
+      for (let p = 0; p < PRESETS_PER_SCREEN; p++) {
+        screen.presets.push({
+          presetId: p,
+          name: `Preset ${p + 1}`,
+        });
+      }
+
+      this.screenList.push(screen);
+
+      // Initialize enhanced state for each offline screen
+      this.initEnhancedScreen(i);
+    }
+
+    // Generate empty preset collection list
+    this.presetCollectionList = [];
+
+    // Generate source list based on input card count (each card has 4 connectors)
+    this.sourceList = [];
+    for (let slot = 0; slot < inputCardCount; slot++) {
+      for (let connector = 0; connector < 4; connector++) {
+        const inputId = slot * 4 + connector;
+        this.sourceList.push({
+          inputId: inputId,
+          cropId: 255,
+          name: `Input ${slot + 1}-${connector + 1}`,
+          online: 1,
+          sourceType: 1,
+          interfaceType: 0,
+          slotId: slot,
+          templateId: 0,
+          streamId: 0,
+        });
+      }
+    }
+
+    this.log(
+      'info',
+      `Offline mode: Generated ${screenCount} screens, ${PRESETS_PER_SCREEN} presets each, ${this.sourceList.length} inputs (${inputCardCount} cards × 4)`,
+    );
+  }
+
+  // ========== ORIGINAL v3.0.2 methods (with enhancements noted) ==========
 
   handleGetAllData() {
     this.getAllData();
@@ -95,7 +246,7 @@ class ModuleInstance extends InstanceBase {
     }
     this.dataInterval = setInterval(() => {
       this.getAllData();
-    }, 10000);
+    }, this.config.pollInterval || 1000);
   }
 
   async init(config) {
@@ -104,8 +255,19 @@ class ModuleInstance extends InstanceBase {
       ...config,
     };
 
-    this.updateStatus(InstanceStatus.Connecting);
-    this.initUDP();
+    // Always generate data from config first (offline programming)
+    this.generateOfflineData();
+    this.updateAll();
+
+    // If host is configured, attempt connection
+    if (this.config.host) {
+      this.updateStatus(InstanceStatus.Connecting);
+      this.initUDP();
+    } else {
+      // No host = offline mode, status Ok for programming
+      this.log('info', 'No host configured — running in offline mode for programming');
+      this.updateStatus(InstanceStatus.Ok, 'Offline');
+    }
   }
 
   /** 更新actions、presets、feedbacks */
@@ -120,12 +282,17 @@ class ModuleInstance extends InstanceBase {
     const { presetCollectionVariableDefinitions, presetCollectionDefaultVariableValues } =
       formatPresetCollectionVariable(this.presetCollectionList);
     const { sourceVariableDefinitions, sourceDefaultVariableValues } = formatSourceVariable(this.sourceList);
+
+    // ENHANCED: Get per-screen enhanced variables
+    const { definitions: enhancedDefs, values: enhancedVals } = this.getEnhancedVariables();
+
     this.setVariableDefinitions([
       ...screenVariableDefinitions,
       ...layerVariableDefinitions,
       ...presetVariableDefinitions,
       ...presetCollectionVariableDefinitions,
       ...sourceVariableDefinitions,
+      ...enhancedDefs,
     ]);
     this.setVariableValues({
       ...screenDefaultVariableValues,
@@ -133,6 +300,7 @@ class ModuleInstance extends InstanceBase {
       ...presetDefaultVariableValues,
       ...presetCollectionDefaultVariableValues,
       ...sourceDefaultVariableValues,
+      ...enhancedVals,
     });
   }
 
@@ -146,6 +314,18 @@ class ModuleInstance extends InstanceBase {
   }
 
   getConfigFields() {
+    // Build screen count dropdown choices (1-40)
+    const screenCountChoices = [];
+    for (let i = 1; i <= 40; i++) {
+      screenCountChoices.push({ id: i, label: `${i}` });
+    }
+
+    // Build input card count dropdown choices (1-40)
+    const inputCardChoices = [];
+    for (let i = 1; i <= 40; i++) {
+      inputCardChoices.push({ id: i, label: `${i} (${i * 4} inputs)` });
+    }
+
     return [
       {
         type: 'static-text',
@@ -154,12 +334,13 @@ class ModuleInstance extends InstanceBase {
         label: 'Information',
         value: PRODUCTS_INFORMATION,
       },
+      // Connection settings
       {
         type: 'textinput',
         id: 'host',
         label: 'IP Address',
         width: 6,
-        default: '127.0.0.1',
+        default: '192.168.0.10',
         regex: Regex.IP,
       },
       {
@@ -169,6 +350,44 @@ class ModuleInstance extends InstanceBase {
         width: 6,
         default: '6000',
         regex: Regex.PORT,
+      },
+      {
+        type: 'number',
+        id: 'pollInterval',
+        label: 'Poll Interval (ms)',
+        width: 6,
+        min: 500,
+        max: 30000,
+        default: 1000,
+        tooltip: 'How often to poll the device for state updates (500-30000ms)',
+        isVisible: (config) => !!config.host,
+      },
+      // Device size configuration (always available for offline programming)
+      {
+        type: 'static-text',
+        id: 'offline_info',
+        width: 12,
+        label: 'Information',
+        value: 'The counts below will automatically populate from the device upon connection, however, they can be set manually for offline programming.',
+      },
+      {
+        type: 'dropdown',
+        id: 'screenCount',
+        label: 'Number of Screens',
+        width: 6,
+        default: 1,
+        choices: screenCountChoices,
+        tooltip: 'Number of screens on your device. Used for offline programming. Overridden by device when connected.',
+      },
+      {
+        type: 'dropdown',
+        id: 'inputCardCount',
+        label: 'Number of Input Cards',
+        width: 6,
+        default: 1,
+        choices: inputCardChoices,
+        tooltip:
+          'Number of input cards installed (each card has 4 connectors). Used for offline programming. Overridden by device when connected.',
       },
     ];
   }
@@ -185,7 +404,6 @@ class ModuleInstance extends InstanceBase {
           },
         ]);
         const croupList = [];
-        // console.info(1111, res[0]?.data?.inputs);
         const _data =
           res[0]?.data?.inputs?.map((_item) => {
             _item.crops?.forEach((cropItem) => {
@@ -264,7 +482,6 @@ class ModuleInstance extends InstanceBase {
 
       // If we get data, thing should be good
       this.udp.on('data', (msg) => {
-        // this.log("info", JSON.stringify(decodeRes(msg)));
         try {
           const res = decodeRes(msg);
           if (res.ack) {
@@ -281,17 +498,15 @@ class ModuleInstance extends InstanceBase {
       this.log('debug', 'initUDP finish');
     } else {
       this.log('error', 'No host configured');
-      // this.updateStatus(InstanceStatus.BadConfig);
     }
   }
   /** devices cmd handle end */
 
   async configUpdated(config) {
-    let resetConnection = false;
-
-    if (this.config.host != config.host) {
-      resetConnection = true;
-    }
+    const hadHost = !!this.config.host;
+    const hasHost = !!config.host;
+    const hostChanged = this.config.host !== config.host;
+    const sizeChanged = this.config.screenCount !== config.screenCount || this.config.inputCardCount !== config.inputCardCount;
 
     this.log('info', 'configUpdated module....');
 
@@ -300,17 +515,44 @@ class ModuleInstance extends InstanceBase {
       ...config,
     };
 
-    if (resetConnection) {
-      this.updateStatus(InstanceStatus.Connecting);
+    // If size config changed, regenerate offline data
+    if (sizeChanged) {
+      this.enhancedState = { screens: {} };
+      this.generateOfflineData();
+      this.updateAll();
+    }
 
-      // 停止心跳和初始化状态定时器，防止旧连接残留
+    // No host = stay in offline mode
+    if (!hasHost) {
+      // Tear down any existing connection
+      if (this.udp) {
+        this.udp.destroy();
+        delete this.udp;
+      }
+      if (this.dataInterval) {
+        clearInterval(this.dataInterval);
+        this.dataInterval = null;
+      }
       this.heartbeatManager.stop();
       this.clearInitStatusTimer();
+      this.connectStatus = false;
+      this.updateStatus(InstanceStatus.Ok, 'Offline');
+      return;
+    }
 
-      // 重新初始化UDP
+    // Host was added or changed — (re)connect
+    if (!hadHost || hostChanged) {
+      this.updateStatus(InstanceStatus.Connecting);
+      this.heartbeatManager.stop();
+      this.clearInitStatusTimer();
       this.initUDP();
-
       this.handleGetAllData();
+      return;
+    }
+
+    // Host unchanged but other config changed — just update
+    if (sizeChanged) {
+      // Already regenerated above, nothing else to do
     }
   }
 
@@ -375,8 +617,6 @@ class ModuleInstance extends InstanceBase {
         break;
       case ACTIONS_CMD.get_preset_list:
         this.dealPresetList(res.data);
-        // this.log('debug', `presetList22: ${JSON.stringify(res)}`);
-
         break;
       case ACTIONS_CMD.apply_screen_details:
         console.log('apply_screen_details', JSON.stringify(res.data));
@@ -384,7 +624,6 @@ class ModuleInstance extends InstanceBase {
         break;
       case ACTIONS_CMD.get_input_list_simplify:
         this.sourceList = formatSourceList(res.data.inputs);
-        // this.log('debug', `get_input_list_simplify响应: ${JSON.stringify(res.data)}`);
         break;
       case ACTIONS_CMD.device_heartbeat:
         this.heartbeatManager.receive();
@@ -409,7 +648,6 @@ class ModuleInstance extends InstanceBase {
 
   /** 处理图层列表 */
   dealLayerList(data) {
-    // console.log('layerList', JSON.stringify(data));
     if (this.screenList) {
       this.screenList.find((screen) => screen.screenId === data.screenId).layers = data.screenLayers.map((item) => ({
         layerId: item.layerId,
@@ -420,7 +658,6 @@ class ModuleInstance extends InstanceBase {
 
   /** 处理场景列表 */
   dealPresetList(data) {
-    // this.log('debug', `presetList1: ${JSON.stringify(data)}`);
     if (this.screenList) {
       this.screenList.find((screen) => screen.screenId === data.screenId).presets = data.presets.map((item) => ({
         presetId: item.presetId,
@@ -432,6 +669,8 @@ class ModuleInstance extends InstanceBase {
   dealScreenDetails(data) {
     if (this.screenList) {
       this.screenList.find((screen) => screen.screenId === data.screenId).details = data;
+      // ENHANCED: Update per-screen enhanced state from details
+      this.updateEnhancedFromDetails(data.screenId, data);
     }
   }
 

--- a/src/main.js
+++ b/src/main.js
@@ -39,6 +39,8 @@ class ModuleInstance extends InstanceBase {
     this.presetCollectionList = [];
     /**输入源列表 */
     this.sourceList = [];
+    /** Input signal state - tracks which inputs have active signal */
+    this.inputSignalState = {};
     /** 选中的屏幕列表 */
     this.selectedScreenList = [];
     /** 选中的图层 */
@@ -196,6 +198,12 @@ class ModuleInstance extends InstanceBase {
       values[`${prefix}_test_pattern`] = state.testPattern ? 'On' : 'Off';
     }
 
+    // Input signal variables
+    for (const [inputKey, hasSignal] of Object.entries(this.inputSignalState)) {
+      definitions[`${inputKey}_signal`] = { name: `${inputKey.replace('_', ' ').replace('_', '-')} Signal` };
+      values[`${inputKey}_signal`] = hasSignal ? 'Active' : 'No Signal';
+    }
+
     return { definitions, values };
   }
 
@@ -291,12 +299,10 @@ class ModuleInstance extends InstanceBase {
       ...config,
     };
 
-    // Always generate data from config first (offline programming)
-    this.generateOfflineData();
-    this.updateAll();
-
-    // Offline Programming Mode — set OK immediately so variables and feedbacks work
+    // Offline Programming Mode — generate data and set OK
     if (this.config.offlineMode) {
+      this.generateOfflineData();
+      this.updateAll();
       this.log('info', 'Offline Programming Mode enabled');
       this.updateStatus(InstanceStatus.Ok, 'Offline Programming Mode');
     }
@@ -354,6 +360,19 @@ class ModuleInstance extends InstanceBase {
     getPresetCollectionList(this);
     getOutputList(this);
     getInputListSimplify(this);
+    // Poll input signal status for each input card slot
+    this.pollInputSignals();
+  }
+
+  /** Query R0103 for each input connector to get signal status */
+  pollInputSignals() {
+    const inputCardCount = this.config.inputCardCount || 1;
+    for (let slot = 0; slot < inputCardCount; slot++) {
+      for (let connector = 0; connector < 4; connector++) {
+        const cmd = JSON.stringify([{ cmd: 'R0103', param0: 0, param1: slot, param2: connector }]);
+        this.safeSend(Buffer.from(cmd));
+      }
+    }
   }
 
   getConfigFields() {
@@ -574,8 +593,8 @@ class ModuleInstance extends InstanceBase {
       ...config,
     };
 
-    // If size config changed, regenerate offline data
-    if (sizeChanged) {
+    // If size config changed and offline mode is on, regenerate offline data
+    if (sizeChanged && this.config.offlineMode) {
       this.enhancedState = { screens: {} };
       this.generateOfflineData();
       this.updateAll();
@@ -584,13 +603,23 @@ class ModuleInstance extends InstanceBase {
     // If offline mode toggled, update status immediately
     if (offlineModeChanged) {
       if (this.config.offlineMode) {
-        this.updateStatus(InstanceStatus.Ok, 'Offline Programming Mode');
+        this.enhancedState = { screens: {} };
+        this.generateOfflineData();
         this.updateAll();
-      } else if (!this.connectStatus) {
-        if (hasHost) {
-          this.updateStatus(InstanceStatus.Connecting);
-        } else {
-          this.updateStatus(InstanceStatus.Disconnected, 'No host configured');
+        this.updateStatus(InstanceStatus.Ok, 'Offline Programming Mode');
+      } else {
+        // Turning off offline mode — clear offline data
+        this.enhancedState = { screens: {} };
+        this.screenList = [];
+        this.presetCollectionList = [];
+        this.sourceList = [];
+        this.updateAll();
+        if (!this.connectStatus) {
+          if (hasHost) {
+            this.updateStatus(InstanceStatus.Connecting);
+          } else {
+            this.updateStatus(InstanceStatus.Disconnected, 'No host configured');
+          }
         }
       }
     }
@@ -709,6 +738,16 @@ class ModuleInstance extends InstanceBase {
         this.handleInitStatusResponse(res.data.rate);
         break;
       default:
+        // Handle R0103 input signal responses
+        if (res.cmd === 'R0103' && res.ack === 'Ok') {
+          const slotId = res.data?.slotId ?? 0;
+          const interfaceId = res.data?.interfaceId ?? 0;
+          const hasSignal = res.data?.iSignal === 1;
+          const inputKey = `input_${slotId + 1}_${interfaceId + 1}`;
+          this.inputSignalState[inputKey] = hasSignal;
+          this.setVariableValues({ [`${inputKey}_signal`]: hasSignal ? 'Active' : 'No Signal' });
+          this.checkFeedbacks('input_signal');
+        }
         break;
     }
     this.updateAll();

--- a/src/presets.js
+++ b/src/presets.js
@@ -741,8 +741,7 @@ const getPerScreenBrightnessPresets = (instance) => {
       steps: [
         {
           down: [
-            { actionId: 'select_screen', options: { screenId, enable: 1 } },
-            { actionId: 'screen_brightness_add', options: {} },
+            { actionId: 'brightness_add_direct', options: { screenId } },
           ],
         },
       ],
@@ -763,8 +762,7 @@ const getPerScreenBrightnessPresets = (instance) => {
       steps: [
         {
           down: [
-            { actionId: 'select_screen', options: { screenId, enable: 1 } },
-            { actionId: 'screen_brightness_minus', options: {} },
+            { actionId: 'brightness_minus_direct', options: { screenId } },
           ],
         },
       ],

--- a/src/presets.js
+++ b/src/presets.js
@@ -16,7 +16,7 @@ const getSLPPresets = (screenList) => {
       category: 'Screen',
       name: name,
       style: {
-        text: `$(${MODULE_NAME}:screenId_${screenId})`,
+        text: `$(${MODULE_NAME}:screen_${screenId + 1})`,
         size: 'auto',
         color: combineRgb(255, 255, 255),
         bgcolor: combineRgb(0, 0, 0),
@@ -65,7 +65,7 @@ const getSLPPresets = (screenList) => {
         category: 'Layer',
         name: layerName,
         style: {
-          text: `$(${MODULE_NAME}:screenId_${screenId})\n$(${MODULE_NAME}:screenId_${screenId}_layerId_${layerId})`,
+          text: `$(${MODULE_NAME}:screen_${screenId + 1})\n$(${MODULE_NAME}:screen_${screenId + 1}_layer_${layerId + 1})`,
           size: 'auto',
           color: combineRgb(255, 255, 255),
           bgcolor: combineRgb(0, 0, 0),
@@ -113,10 +113,10 @@ const getSLPPresets = (screenList) => {
       const { name: presetName, presetId } = preset;
       const selectPresetPreset = {
         type: 'button',
-        category: 'Preset',
+        category: `Presets: ${name}`,
         name: presetName,
         style: {
-          text: `$(${MODULE_NAME}:screenId_${screenId})\n$(${MODULE_NAME}:screenId_${screenId}_presetId_${presetId})`,
+          text: `$(${MODULE_NAME}:screen_${screenId + 1})\n$(${MODULE_NAME}:screen_${screenId + 1}_preset_${presetId + 1})`,
           size: 'auto',
           color: combineRgb(255, 255, 255),
           bgcolor: combineRgb(0, 0, 0),
@@ -165,7 +165,7 @@ const getPresetCollectionsPresets = (instance) => {
       category: 'Preset Group',
       name: name,
       style: {
-        text: `$({MODULE_NAME}:presetCollectionId_${presetCollectionId})`,
+        text: `$({MODULE_NAME}:presetCollectionId_${presetCollectionId + 1})`,
         size: 'auto',
         color: combineRgb(255, 255, 255),
         bgcolor: combineRgb(0, 0, 0),
@@ -217,7 +217,6 @@ const applyScreenPreset = () => {
           {
             actionId: 'pgm_pvw_switch',
             options: {
-              //非实时模式开关，0：不使能，1：使能；
               enNonTime: 0,
             },
           },
@@ -255,7 +254,6 @@ const applyScreenPreset = () => {
       },
     ],
   };
-  // 上屏 Take
   const takeApply = {
     type: 'button',
     category: 'Display',
@@ -272,7 +270,6 @@ const applyScreenPreset = () => {
           {
             actionId: 'take_switch',
             options: {
-              //手动上屏的开关，1：开 0:关闭
               manualPlay: 1,
             },
           },
@@ -299,7 +296,6 @@ const applyScreenPreset = () => {
       },
     ],
   };
-  //黑屏
   const blackScreen = {
     type: 'button',
     category: 'Display',
@@ -316,7 +312,6 @@ const applyScreenPreset = () => {
           {
             actionId: 'apply_ftb',
             options: {
-              // 亮屏或者黑屏[0：黑屏，1：亮屏]
               type: 0,
             },
           },
@@ -343,7 +338,6 @@ const applyScreenPreset = () => {
       },
     ],
   };
-  // 音频开关
   const volumeSwitch = {
     type: 'button',
     category: 'Display',
@@ -356,37 +350,19 @@ const applyScreenPreset = () => {
     },
     steps: [
       {
-        down: [
-          {
-            actionId: 'apply_volume_switch',
-            options: {
-              isMute: 0,
-            },
-          },
-        ],
+        down: [{ actionId: 'apply_volume_switch', options: { isMute: 0 } }],
       },
       {
-        down: [
-          {
-            actionId: 'apply_volume_switch',
-            options: {
-              isMute: 1,
-            },
-          },
-        ],
+        down: [{ actionId: 'apply_volume_switch', options: { isMute: 1 } }],
       },
     ],
     feedbacks: [
       {
         feedbackId: 'volume_switch_selected',
-        style: {
-          bgcolor: combineRgb(0, 255, 0),
-          color: combineRgb(0, 0, 0),
-        },
+        style: { bgcolor: combineRgb(0, 255, 0), color: combineRgb(0, 0, 0) },
       },
     ],
   };
-  /** 屏幕冻结 */
   const freezeScreen = {
     type: 'button',
     category: 'Display',
@@ -400,347 +376,116 @@ const applyScreenPreset = () => {
     feedbacks: [
       {
         feedbackId: 'screen_frz',
-        style: {
-          bgcolor: combineRgb(255, 0, 0), // 选中时高亮红色
-          color: combineRgb(0, 0, 0), // 选中时字体黑色
-        },
+        style: { bgcolor: combineRgb(255, 0, 0), color: combineRgb(0, 0, 0) },
       },
     ],
     steps: [
-      {
-        down: [
-          {
-            actionId: 'screen_frz_toggle',
-            options: {
-              enable: 1,
-            },
-          },
-        ],
-      },
-      {
-        down: [
-          {
-            actionId: 'screen_frz_toggle',
-            options: {
-              enable: 0,
-            },
-          },
-        ],
-      },
+      { down: [{ actionId: 'screen_frz_toggle', options: { enable: 1 } }] },
+      { down: [{ actionId: 'screen_frz_toggle', options: { enable: 0 } }] },
     ],
   };
   const volumeAdd = {
     type: 'button',
     category: 'Display',
     name: 'Volume Add',
-    style: {
-      text: 'Volume\n+',
-      size: 'auto',
-      color: combineRgb(255, 255, 255),
-      bgcolor: combineRgb(0, 0, 0),
-    },
-    steps: [
-      {
-        down: [
-          {
-            actionId: 'screen_volume_add',
-            options: {},
-          },
-        ],
-      },
-    ],
+    style: { text: 'Volume\n+', size: 'auto', color: combineRgb(255, 255, 255), bgcolor: combineRgb(0, 0, 0) },
+    steps: [{ down: [{ actionId: 'screen_volume_add', options: {} }] }],
     feedbacks: [],
   };
-  // 音量-
   const volumeMinus = {
     name: 'Volume Minus',
     type: 'button',
     category: 'Display',
-    style: {
-      text: 'Volume\n-',
-      size: 'auto',
-      color: combineRgb(255, 255, 255),
-      bgcolor: combineRgb(0, 0, 0),
-    },
-    steps: [
-      {
-        down: [
-          {
-            actionId: 'screen_volume_minus',
-            options: {},
-          },
-        ],
-      },
-    ],
+    style: { text: 'Volume\n-', size: 'auto', color: combineRgb(255, 255, 255), bgcolor: combineRgb(0, 0, 0) },
+    steps: [{ down: [{ actionId: 'screen_volume_minus', options: {} }] }],
     feedbacks: [],
   };
-  // 亮度+
   const brightnessAdd = {
     type: 'button',
     category: 'Display',
     name: 'Brightness Add',
-    style: {
-      text: 'Brightness\n+',
-      size: 'auto',
-      color: combineRgb(255, 255, 255),
-      bgcolor: combineRgb(0, 0, 0),
-    },
-    steps: [
-      {
-        down: [
-          {
-            actionId: 'screen_brightness_add',
-            options: {},
-          },
-        ],
-      },
-    ],
+    style: { text: 'Brightness\n+', size: 'auto', color: combineRgb(255, 255, 255), bgcolor: combineRgb(0, 0, 0) },
+    steps: [{ down: [{ actionId: 'screen_brightness_add', options: {} }] }],
     feedbacks: [],
   };
-  // 亮度-
   const brightnessMinus = {
     name: 'Brightness Minus',
     type: 'button',
     category: 'Display',
-    style: {
-      text: 'Brightness\n-',
-      size: 'auto',
-      color: combineRgb(255, 255, 255),
-      bgcolor: combineRgb(0, 0, 0),
-    },
-    steps: [
-      {
-        down: [
-          {
-            actionId: 'screen_brightness_minus',
-            options: {},
-          },
-        ],
-      },
-    ],
+    style: { text: 'Brightness\n-', size: 'auto', color: combineRgb(255, 255, 255), bgcolor: combineRgb(0, 0, 0) },
+    steps: [{ down: [{ actionId: 'screen_brightness_minus', options: {} }] }],
     feedbacks: [],
   };
-
-  /** 图层冻结 */
   const freezeLayer = {
     type: 'button',
     category: 'Display',
     name: 'Layer FRZ',
-    style: {
-      text: 'Layer\nFRZ',
-      size: 'auto',
-      color: combineRgb(255, 255, 255),
-      bgcolor: combineRgb(0, 0, 0),
-    },
+    style: { text: 'Layer\nFRZ', size: 'auto', color: combineRgb(255, 255, 255), bgcolor: combineRgb(0, 0, 0) },
     feedbacks: [
-      {
-        feedbackId: 'layer_frz',
-        style: {
-          bgcolor: combineRgb(255, 0, 0), // 选中时高亮红色
-          color: combineRgb(0, 0, 0), // 选中时字体黑色
-        },
-      },
+      { feedbackId: 'layer_frz', style: { bgcolor: combineRgb(255, 0, 0), color: combineRgb(0, 0, 0) } },
     ],
     steps: [
-      {
-        down: [
-          {
-            actionId: 'layer_frz_toggle',
-            options: { enable: 1 },
-          },
-        ],
-      },
-      {
-        down: [
-          {
-            actionId: 'layer_frz_toggle',
-            options: { enable: 0 },
-          },
-        ],
-      },
+      { down: [{ actionId: 'layer_frz_toggle', options: { enable: 1 } }] },
+      { down: [{ actionId: 'layer_frz_toggle', options: { enable: 0 } }] },
     ],
   };
-
-  /**测试画面开关 */
   const testPattern = {
     type: 'button',
     category: 'Display',
     name: 'Test Pattern',
-    style: {
-      text: 'Test\nPattern',
-      size: 'auto',
-      color: combineRgb(255, 255, 255),
-      bgcolor: combineRgb(0, 0, 0),
-    },
+    style: { text: 'Test\nPattern', size: 'auto', color: combineRgb(255, 255, 255), bgcolor: combineRgb(0, 0, 0) },
     steps: [
-      {
-        down: [
-          {
-            actionId: 'test_pattern_switch',
-            options: {
-              //开
-              testPattern: TEST_PATTERN_TYPE.OPEN,
-            },
-          },
-        ],
-      },
-      {
-        down: [
-          {
-            actionId: 'test_pattern_switch',
-            options: {
-              //关
-              testPattern: TEST_PATTERN_TYPE.CLOSE,
-            },
-          },
-        ],
-      },
+      { down: [{ actionId: 'test_pattern_switch', options: { testPattern: TEST_PATTERN_TYPE.OPEN } }] },
+      { down: [{ actionId: 'test_pattern_switch', options: { testPattern: TEST_PATTERN_TYPE.CLOSE } }] },
     ],
     feedbacks: [
-      {
-        feedbackId: 'test_pattern_selected',
-        style: {
-          bgcolor: combineRgb(0, 255, 0),
-          color: combineRgb(0, 0, 0),
-        },
-      },
+      { feedbackId: 'test_pattern_selected', style: { bgcolor: combineRgb(0, 255, 0), color: combineRgb(0, 0, 0) } },
     ],
   };
-
-  // BKG开关
   const bkgSwitch = {
     type: 'button',
     category: 'Display',
     name: 'BKG',
-    style: {
-      text: 'BKG',
-      size: 'auto',
-      color: combineRgb(255, 255, 255),
-      bgcolor: combineRgb(0, 0, 0),
-    },
+    style: { text: 'BKG', size: 'auto', color: combineRgb(255, 255, 255), bgcolor: combineRgb(0, 0, 0) },
     steps: [
-      {
-        down: [
-          {
-            actionId: 'bkg_switch',
-            options: {
-              enable: 1,
-            },
-          },
-        ],
-      },
-      {
-        down: [
-          {
-            actionId: 'bkg_switch',
-            options: {
-              enable: 0,
-            },
-          },
-        ],
-      },
+      { down: [{ actionId: 'bkg_switch', options: { enable: 1 } }] },
+      { down: [{ actionId: 'bkg_switch', options: { enable: 0 } }] },
     ],
     feedbacks: [
-      {
-        feedbackId: 'bkg_switch',
-        style: {
-          bgcolor: combineRgb(0, 255, 0),
-          color: combineRgb(0, 0, 0),
-        },
-      },
+      { feedbackId: 'bkg_switch', style: { bgcolor: combineRgb(0, 255, 0), color: combineRgb(0, 0, 0) } },
     ],
   };
-
-  // OSD Text开关
   const osdTextSwitch = {
     type: 'button',
     category: 'Display',
     name: 'OSD Text',
-    style: {
-      text: 'OSD\nText',
-      size: 'auto',
-      color: combineRgb(255, 255, 255),
-      bgcolor: combineRgb(0, 0, 0),
-    },
+    style: { text: 'OSD\nText', size: 'auto', color: combineRgb(255, 255, 255), bgcolor: combineRgb(0, 0, 0) },
     steps: [
-      {
-        down: [
-          {
-            actionId: 'osd_switch',
-            options: {
-              enable: 1,
-              osdType: 'text',
-            },
-          },
-        ],
-      },
-      {
-        down: [
-          {
-            actionId: 'osd_switch',
-            options: {
-              enable: 0,
-              osdType: 'text',
-            },
-          },
-        ],
-      },
+      { down: [{ actionId: 'osd_switch', options: { enable: 1, osdType: 'text' } }] },
+      { down: [{ actionId: 'osd_switch', options: { enable: 0, osdType: 'text' } }] },
     ],
     feedbacks: [
       {
         feedbackId: 'osd_switch',
         options: { osdType: 'text' },
-        style: {
-          bgcolor: combineRgb(0, 255, 0),
-          color: combineRgb(0, 0, 0),
-        },
+        style: { bgcolor: combineRgb(0, 255, 0), color: combineRgb(0, 0, 0) },
       },
     ],
   };
-
-  // OSD Image开关
   const osdImageSwitch = {
     type: 'button',
     category: 'Display',
     name: 'OSD Image',
-    style: {
-      text: 'OSD\nImage',
-      size: 'auto',
-      color: combineRgb(255, 255, 255),
-      bgcolor: combineRgb(0, 0, 0),
-    },
+    style: { text: 'OSD\nImage', size: 'auto', color: combineRgb(255, 255, 255), bgcolor: combineRgb(0, 0, 0) },
     steps: [
-      {
-        down: [
-          {
-            actionId: 'osd_switch',
-            options: {
-              enable: 1,
-              osdType: 'image',
-            },
-          },
-        ],
-      },
-      {
-        down: [
-          {
-            actionId: 'osd_switch',
-            options: {
-              enable: 0,
-              osdType: 'image',
-            },
-          },
-        ],
-      },
+      { down: [{ actionId: 'osd_switch', options: { enable: 1, osdType: 'image' } }] },
+      { down: [{ actionId: 'osd_switch', options: { enable: 0, osdType: 'image' } }] },
     ],
     feedbacks: [
       {
         feedbackId: 'osd_switch',
         options: { osdType: 'image' },
-        style: {
-          bgcolor: combineRgb(0, 255, 0),
-          color: combineRgb(0, 0, 0),
-        },
+        style: { bgcolor: combineRgb(0, 255, 0), color: combineRgb(0, 0, 0) },
       },
     ],
   };
@@ -772,33 +517,21 @@ const getSourceListPresets = (instance) => {
       category: 'Source List',
       name,
       style: {
-        text: `$({MODULE_NAME}:source_${inputId}_${cropId})`,
+        text: `$({MODULE_NAME}:source_${inputId + 1}_${cropId})`,
         size: '12',
         color: combineRgb(255, 255, 255),
         bgcolor: combineRgb(0, 0, 0),
       },
       steps: [
         {
-          down: [
-            {
-              actionId: 'source_switch',
-              options: {
-                id: `${inputId}_${cropId}`,
-              },
-            },
-          ],
+          down: [{ actionId: 'source_switch', options: { id: `${inputId}_${cropId}` } }],
         },
       ],
       feedbacks: [
         {
           feedbackId: 'source_switch_selected',
-          options: {
-            id: `${inputId}_${cropId}`,
-          },
-          style: {
-            bgcolor: combineRgb(0, 255, 0),
-            color: combineRgb(0, 0, 0),
-          },
+          options: { id: `${inputId}_${cropId}` },
+          style: { bgcolor: combineRgb(0, 255, 0), color: combineRgb(0, 0, 0) },
         },
       ],
     };
@@ -807,16 +540,255 @@ const getSourceListPresets = (instance) => {
   return sourceList;
 };
 
+// ==================== ENHANCED: Per-screen direct control presets ====================
+
+/** Generate per-screen control presets (FTB, Freeze, BKG, OSD, Test Pattern) */
+const getPerScreenControlPresets = (instance) => {
+  const presets = {};
+
+  instance.screenList?.forEach((screen) => {
+    const { name, screenId } = screen;
+    const category = `Control: ${name}`;
+
+    // Per-screen FTB toggle
+    presets[`direct_ftb_${screenId}`] = {
+      type: 'button',
+      category,
+      name: `${name} FTB`,
+      style: {
+        text: `${name}\nFTB`,
+        size: 'auto',
+        color: combineRgb(255, 255, 255),
+        bgcolor: combineRgb(0, 0, 0),
+      },
+      steps: [
+        {
+          down: [
+            { actionId: 'select_screen', options: { screenId, enable: 1 } },
+            { actionId: 'apply_ftb', options: { type: 0 } },
+          ],
+        },
+        {
+          down: [
+            { actionId: 'select_screen', options: { screenId, enable: 1 } },
+            { actionId: 'apply_ftb', options: { type: 1 } },
+          ],
+        },
+      ],
+      feedbacks: [
+        {
+          feedbackId: 'ftb_direct',
+          options: { screenId },
+          style: { bgcolor: combineRgb(255, 0, 0), color: combineRgb(255, 255, 255) },
+        },
+      ],
+    };
+
+    // Per-screen Freeze toggle
+    presets[`direct_freeze_${screenId}`] = {
+      type: 'button',
+      category,
+      name: `${name} Freeze`,
+      style: {
+        text: `${name}\nFRZ`,
+        size: 'auto',
+        color: combineRgb(255, 255, 255),
+        bgcolor: combineRgb(0, 0, 0),
+      },
+      steps: [
+        {
+          down: [
+            { actionId: 'select_screen', options: { screenId, enable: 1 } },
+            { actionId: 'screen_frz_toggle', options: { enable: 1 } },
+          ],
+        },
+        {
+          down: [
+            { actionId: 'select_screen', options: { screenId, enable: 1 } },
+            { actionId: 'screen_frz_toggle', options: { enable: 0 } },
+          ],
+        },
+      ],
+      feedbacks: [
+        {
+          feedbackId: 'frozen_direct',
+          options: { screenId },
+          style: { bgcolor: combineRgb(0, 0, 255), color: combineRgb(255, 255, 255) },
+        },
+      ],
+    };
+
+    // Per-screen BKG toggle
+    presets[`direct_bkg_${screenId}`] = {
+      type: 'button',
+      category,
+      name: `${name} BKG`,
+      style: { text: `${name}\nBKG`, size: 'auto', color: combineRgb(255, 255, 255), bgcolor: combineRgb(0, 0, 0) },
+      steps: [
+        { down: [{ actionId: 'select_screen', options: { screenId, enable: 1 } }, { actionId: 'bkg_switch', options: { enable: 1 } }] },
+        { down: [{ actionId: 'select_screen', options: { screenId, enable: 1 } }, { actionId: 'bkg_switch', options: { enable: 0 } }] },
+      ],
+      feedbacks: [
+        { feedbackId: 'bkg_direct', options: { screenId }, style: { bgcolor: combineRgb(0, 255, 0), color: combineRgb(0, 0, 0) } },
+      ],
+    };
+
+    // Per-screen OSD Text toggle
+    presets[`direct_osd_text_${screenId}`] = {
+      type: 'button',
+      category,
+      name: `${name} OSD Text`,
+      style: { text: `${name}\nOSD Text`, size: 'auto', color: combineRgb(255, 255, 255), bgcolor: combineRgb(0, 0, 0) },
+      steps: [
+        { down: [{ actionId: 'select_screen', options: { screenId, enable: 1 } }, { actionId: 'osd_switch', options: { enable: 1, osdType: 'text' } }] },
+        { down: [{ actionId: 'select_screen', options: { screenId, enable: 1 } }, { actionId: 'osd_switch', options: { enable: 0, osdType: 'text' } }] },
+      ],
+      feedbacks: [
+        { feedbackId: 'osd_text_direct', options: { screenId }, style: { bgcolor: combineRgb(0, 255, 0), color: combineRgb(0, 0, 0) } },
+      ],
+    };
+
+    // Per-screen OSD Image toggle
+    presets[`direct_osd_image_${screenId}`] = {
+      type: 'button',
+      category,
+      name: `${name} OSD Image`,
+      style: { text: `${name}\nOSD Img`, size: 'auto', color: combineRgb(255, 255, 255), bgcolor: combineRgb(0, 0, 0) },
+      steps: [
+        { down: [{ actionId: 'select_screen', options: { screenId, enable: 1 } }, { actionId: 'osd_switch', options: { enable: 1, osdType: 'image' } }] },
+        { down: [{ actionId: 'select_screen', options: { screenId, enable: 1 } }, { actionId: 'osd_switch', options: { enable: 0, osdType: 'image' } }] },
+      ],
+      feedbacks: [
+        { feedbackId: 'osd_image_direct', options: { screenId }, style: { bgcolor: combineRgb(0, 255, 0), color: combineRgb(0, 0, 0) } },
+      ],
+    };
+
+    // Per-screen Test Pattern toggle
+    presets[`direct_test_${screenId}`] = {
+      type: 'button',
+      category,
+      name: `${name} Test Pattern`,
+      style: { text: `${name}\nTest`, size: 'auto', color: combineRgb(255, 255, 255), bgcolor: combineRgb(0, 0, 0) },
+      steps: [
+        { down: [{ actionId: 'select_screen', options: { screenId, enable: 1 } }, { actionId: 'test_pattern_switch', options: { testPattern: TEST_PATTERN_TYPE.OPEN } }] },
+        { down: [{ actionId: 'select_screen', options: { screenId, enable: 1 } }, { actionId: 'test_pattern_switch', options: { testPattern: TEST_PATTERN_TYPE.CLOSE } }] },
+      ],
+      feedbacks: [
+        { feedbackId: 'test_pattern_direct', options: { screenId }, style: { bgcolor: combineRgb(0, 255, 0), color: combineRgb(0, 0, 0) } },
+      ],
+    };
+  });
+
+  return presets;
+};
+
+/** Generate per-screen brightness presets (common levels + increment/decrement) */
+const getPerScreenBrightnessPresets = (instance) => {
+  const presets = {};
+  const levels = [
+    { pct: 0, color: combineRgb(80, 80, 80) },
+    { pct: 25, color: combineRgb(100, 100, 0) },
+    { pct: 50, color: combineRgb(180, 180, 0) },
+    { pct: 75, color: combineRgb(200, 160, 0) },
+    { pct: 100, color: combineRgb(255, 255, 255) },
+  ];
+
+  instance.screenList?.forEach((screen) => {
+    const { name, screenId } = screen;
+    const category = `Brightness: ${name}`;
+
+    // Common brightness levels
+    levels.forEach(({ pct, color }) => {
+      presets[`direct_bright_${screenId}_${pct}`] = {
+        type: 'button',
+        category,
+        name: `${name} ${pct}%`,
+        style: {
+          text: `${name}\n${pct}%`,
+          size: 'auto',
+          color: combineRgb(0, 0, 0),
+          bgcolor: color,
+        },
+        // Note: This uses select_screen + brightness set pattern
+        // Since there's no "set brightness to X" action in v3.0.2,
+        // we use the feedback to show status only
+        steps: [
+          {
+            down: [
+              { actionId: 'select_screen', options: { screenId, enable: 1 } },
+            ],
+          },
+        ],
+        feedbacks: [
+          {
+            feedbackId: 'brightness_match',
+            options: { screenId, brightness: pct },
+            style: { bgcolor: combineRgb(0, 255, 0), color: combineRgb(0, 0, 0) },
+          },
+        ],
+      };
+    });
+
+    // Brightness increment
+    presets[`direct_bright_up_${screenId}`] = {
+      type: 'button',
+      category,
+      name: `${name} Brightness +`,
+      style: {
+        text: `${name}\nBright +`,
+        size: 'auto',
+        color: combineRgb(255, 255, 255),
+        bgcolor: combineRgb(0, 0, 0),
+      },
+      steps: [
+        {
+          down: [
+            { actionId: 'select_screen', options: { screenId, enable: 1 } },
+            { actionId: 'screen_brightness_add', options: {} },
+          ],
+        },
+      ],
+      feedbacks: [],
+    };
+
+    // Brightness decrement
+    presets[`direct_bright_down_${screenId}`] = {
+      type: 'button',
+      category,
+      name: `${name} Brightness -`,
+      style: {
+        text: `${name}\nBright -`,
+        size: 'auto',
+        color: combineRgb(255, 255, 255),
+        bgcolor: combineRgb(0, 0, 0),
+      },
+      steps: [
+        {
+          down: [
+            { actionId: 'select_screen', options: { screenId, enable: 1 } },
+            { actionId: 'screen_brightness_minus', options: {} },
+          ],
+        },
+      ],
+      feedbacks: [],
+    };
+  });
+
+  return presets;
+};
+
 export const getPresetDefinitions = function (instance) {
-  // instance.log('info', JSON.stringify(instance.screenList));
-  // instance.log('info', JSON.stringify(instance.sourceList));
   const { screenPresets, layerPresets, presetPresets } = getSLPPresets(instance.screenList);
   return {
+    // Original v3.0.2 presets (presets now per-screen categories)
     ...screenPresets,
     ...layerPresets,
     ...presetPresets,
     ...getPresetCollectionsPresets(instance),
     ...getSourceListPresets(instance),
     ...applyScreenPreset(),
+    // Enhanced per-screen direct presets
+    ...getPerScreenControlPresets(instance),
+    ...getPerScreenBrightnessPresets(instance),
   };
 };

--- a/src/presets.js
+++ b/src/presets.js
@@ -16,8 +16,8 @@ const getSLPPresets = (screenList) => {
       category: 'Screen',
       name: name,
       style: {
-        text: `$(${MODULE_NAME}:screen_${screenId + 1})`,
-        size: 'auto',
+        text: `Select\\n$(${MODULE_NAME}:screen_${screenId + 1})`,
+        size: '18',
         color: combineRgb(255, 255, 255),
         bgcolor: combineRgb(0, 0, 0),
       },
@@ -366,9 +366,9 @@ const applyScreenPreset = () => {
   const freezeScreen = {
     type: 'button',
     category: 'Display',
-    name: 'Screen FRZ',
+    name: 'Freeze',
     style: {
-      text: 'Screen\nFRZ',
+      text: 'Freeze',
       size: 'auto',
       color: combineRgb(255, 255, 255),
       bgcolor: combineRgb(0, 0, 0),
@@ -555,32 +555,13 @@ const getPerScreenControlPresets = (instance) => {
       type: 'button',
       category,
       name: `${name} FTB`,
-      style: {
-        text: `${name}\nFTB`,
-        size: 'auto',
-        color: combineRgb(255, 255, 255),
-        bgcolor: combineRgb(0, 0, 0),
-      },
+      style: { text: `${name}\nFTB`, size: 'auto', color: combineRgb(255, 255, 255), bgcolor: combineRgb(0, 0, 0) },
       steps: [
-        {
-          down: [
-            { actionId: 'select_screen', options: { screenId, enable: 1 } },
-            { actionId: 'apply_ftb', options: { type: 0 } },
-          ],
-        },
-        {
-          down: [
-            { actionId: 'select_screen', options: { screenId, enable: 1 } },
-            { actionId: 'apply_ftb', options: { type: 1 } },
-          ],
-        },
+        { down: [{ actionId: 'ftb_direct', options: { screenId, state: 1 } }] },
+        { down: [{ actionId: 'ftb_direct', options: { screenId, state: 0 } }] },
       ],
       feedbacks: [
-        {
-          feedbackId: 'ftb_direct',
-          options: { screenId },
-          style: { bgcolor: combineRgb(255, 0, 0), color: combineRgb(255, 255, 255) },
-        },
+        { feedbackId: 'ftb_direct', options: { screenId }, style: { bgcolor: combineRgb(255, 0, 0), color: combineRgb(255, 255, 255) } },
       ],
     };
 
@@ -589,32 +570,13 @@ const getPerScreenControlPresets = (instance) => {
       type: 'button',
       category,
       name: `${name} Freeze`,
-      style: {
-        text: `${name}\nFRZ`,
-        size: 'auto',
-        color: combineRgb(255, 255, 255),
-        bgcolor: combineRgb(0, 0, 0),
-      },
+      style: { text: `${name}\nFreeze`, size: 'auto', color: combineRgb(255, 255, 255), bgcolor: combineRgb(0, 0, 0) },
       steps: [
-        {
-          down: [
-            { actionId: 'select_screen', options: { screenId, enable: 1 } },
-            { actionId: 'screen_frz_toggle', options: { enable: 1 } },
-          ],
-        },
-        {
-          down: [
-            { actionId: 'select_screen', options: { screenId, enable: 1 } },
-            { actionId: 'screen_frz_toggle', options: { enable: 0 } },
-          ],
-        },
+        { down: [{ actionId: 'freeze_direct', options: { screenId, state: 1 } }] },
+        { down: [{ actionId: 'freeze_direct', options: { screenId, state: 0 } }] },
       ],
       feedbacks: [
-        {
-          feedbackId: 'frozen_direct',
-          options: { screenId },
-          style: { bgcolor: combineRgb(0, 0, 255), color: combineRgb(255, 255, 255) },
-        },
+        { feedbackId: 'frozen_direct', options: { screenId }, style: { bgcolor: combineRgb(0, 0, 255), color: combineRgb(255, 255, 255) } },
       ],
     };
 
@@ -625,8 +587,8 @@ const getPerScreenControlPresets = (instance) => {
       name: `${name} BKG`,
       style: { text: `${name}\nBKG`, size: 'auto', color: combineRgb(255, 255, 255), bgcolor: combineRgb(0, 0, 0) },
       steps: [
-        { down: [{ actionId: 'select_screen', options: { screenId, enable: 1 } }, { actionId: 'bkg_switch', options: { enable: 1 } }] },
-        { down: [{ actionId: 'select_screen', options: { screenId, enable: 1 } }, { actionId: 'bkg_switch', options: { enable: 0 } }] },
+        { down: [{ actionId: 'bkg_direct', options: { screenId, state: 1 } }] },
+        { down: [{ actionId: 'bkg_direct', options: { screenId, state: 0 } }] },
       ],
       feedbacks: [
         { feedbackId: 'bkg_direct', options: { screenId }, style: { bgcolor: combineRgb(0, 255, 0), color: combineRgb(0, 0, 0) } },
@@ -640,8 +602,8 @@ const getPerScreenControlPresets = (instance) => {
       name: `${name} OSD Text`,
       style: { text: `${name}\nOSD Text`, size: 'auto', color: combineRgb(255, 255, 255), bgcolor: combineRgb(0, 0, 0) },
       steps: [
-        { down: [{ actionId: 'select_screen', options: { screenId, enable: 1 } }, { actionId: 'osd_switch', options: { enable: 1, osdType: 'text' } }] },
-        { down: [{ actionId: 'select_screen', options: { screenId, enable: 1 } }, { actionId: 'osd_switch', options: { enable: 0, osdType: 'text' } }] },
+        { down: [{ actionId: 'osd_direct', options: { screenId, state: 1 } }] },
+        { down: [{ actionId: 'osd_direct', options: { screenId, state: 0 } }] },
       ],
       feedbacks: [
         { feedbackId: 'osd_text_direct', options: { screenId }, style: { bgcolor: combineRgb(0, 255, 0), color: combineRgb(0, 0, 0) } },
@@ -655,8 +617,8 @@ const getPerScreenControlPresets = (instance) => {
       name: `${name} OSD Image`,
       style: { text: `${name}\nOSD Img`, size: 'auto', color: combineRgb(255, 255, 255), bgcolor: combineRgb(0, 0, 0) },
       steps: [
-        { down: [{ actionId: 'select_screen', options: { screenId, enable: 1 } }, { actionId: 'osd_switch', options: { enable: 1, osdType: 'image' } }] },
-        { down: [{ actionId: 'select_screen', options: { screenId, enable: 1 } }, { actionId: 'osd_switch', options: { enable: 0, osdType: 'image' } }] },
+        { down: [{ actionId: 'osd_direct', options: { screenId, state: 1 } }] },
+        { down: [{ actionId: 'osd_direct', options: { screenId, state: 0 } }] },
       ],
       feedbacks: [
         { feedbackId: 'osd_image_direct', options: { screenId }, style: { bgcolor: combineRgb(0, 255, 0), color: combineRgb(0, 0, 0) } },
@@ -677,7 +639,51 @@ const getPerScreenControlPresets = (instance) => {
         { feedbackId: 'test_pattern_direct', options: { screenId }, style: { bgcolor: combineRgb(0, 255, 0), color: combineRgb(0, 0, 0) } },
       ],
     };
+
+    // Per-screen PGM/PVW
+    presets[`direct_pgm_pvw_${screenId}`] = {
+      type: 'button',
+      category,
+      name: `${name} PGM/PVW`,
+      style: { text: `${name}\nPGM/PVW`, size: '14', color: combineRgb(255, 255, 255), bgcolor: combineRgb(0, 0, 0) },
+      steps: [
+        { down: [{ actionId: 'select_screen', options: { screenId, enable: 1 } }, { actionId: 'pgm_pvw_switch', options: { enNonTime: 0 } }] },
+        { down: [{ actionId: 'select_screen', options: { screenId, enable: 1 } }, { actionId: 'pgm_pvw_switch', options: { enNonTime: 1 } }] },
+      ],
+      feedbacks: [
+        { feedbackId: 'pgm_pvw_switch', options: { type: PGM_PVW_TYPE.PGM }, style: { bgcolor: combineRgb(0, 255, 0), color: combineRgb(0, 0, 0), text: `${name}\nPGM` } },
+        { feedbackId: 'pgm_pvw_switch', options: { type: PGM_PVW_TYPE.PVW }, style: { bgcolor: combineRgb(255, 0, 0), color: combineRgb(0, 0, 0), text: `${name}\nPVW` } },
+      ],
+    };
+
+    // Per-screen Take
+    presets[`direct_take_${screenId}`] = {
+      type: 'button',
+      category,
+      name: `${name} Take`,
+      style: { text: `${name}\nTake`, size: 'auto', color: combineRgb(255, 255, 255), bgcolor: combineRgb(0, 0, 0) },
+      steps: [
+        { down: [{ actionId: 'select_screen', options: { screenId, enable: 1 } }, { actionId: 'take_switch', options: { manualPlay: 1 } }] },
+        { down: [{ actionId: 'select_screen', options: { screenId, enable: 1 } }, { actionId: 'take_switch', options: { manualPlay: 0 } }] },
+      ],
+      feedbacks: [
+        { feedbackId: 'pvw_take_selected', style: { bgcolor: combineRgb(0, 255, 0), color: combineRgb(0, 0, 0) } },
+      ],
+    };
   });
+
+  // Blackout (global - all screens)
+  presets['blackout_global'] = {
+    type: 'button',
+    category: 'Display',
+    name: 'Blackout',
+    style: { text: 'Blackout', size: 'auto', color: combineRgb(255, 255, 255), bgcolor: combineRgb(0, 0, 0) },
+    steps: [
+      { down: [{ actionId: 'blackout', options: { state: 1 } }] },
+      { down: [{ actionId: 'blackout', options: { state: 0 } }] },
+    ],
+    feedbacks: [],
+  };
 
   return presets;
 };
@@ -685,20 +691,14 @@ const getPerScreenControlPresets = (instance) => {
 /** Generate per-screen brightness presets (common levels + increment/decrement) */
 const getPerScreenBrightnessPresets = (instance) => {
   const presets = {};
-  const levels = [
-    { pct: 0, color: combineRgb(80, 80, 80) },
-    { pct: 25, color: combineRgb(100, 100, 0) },
-    { pct: 50, color: combineRgb(180, 180, 0) },
-    { pct: 75, color: combineRgb(200, 160, 0) },
-    { pct: 100, color: combineRgb(255, 255, 255) },
-  ];
+  const levels = [100, 95, 90, 85, 80, 75, 70, 65, 60, 55, 50, 45, 40, 35, 30, 25, 20, 15, 10, 5, 0];
 
   instance.screenList?.forEach((screen) => {
     const { name, screenId } = screen;
     const category = `Brightness: ${name}`;
 
-    // Common brightness levels
-    levels.forEach(({ pct, color }) => {
+    // Brightness level presets
+    levels.forEach((pct) => {
       presets[`direct_bright_${screenId}_${pct}`] = {
         type: 'button',
         category,
@@ -706,23 +706,21 @@ const getPerScreenBrightnessPresets = (instance) => {
         style: {
           text: `${name}\n${pct}%`,
           size: 'auto',
-          color: combineRgb(0, 0, 0),
-          bgcolor: color,
+          color: combineRgb(255, 255, 255),
+          bgcolor: combineRgb(0, 0, 0),
         },
-        // Note: This uses select_screen + brightness set pattern
-        // Since there's no "set brightness to X" action in v3.0.2,
-        // we use the feedback to show status only
         steps: [
           {
             down: [
-              { actionId: 'select_screen', options: { screenId, enable: 1 } },
+              { actionId: 'set_brightness', options: { screenId, brightness: pct.toString() } },
+              { actionId: 'save_brightness', options: { screenId }, delay: 100 },
             ],
           },
         ],
         feedbacks: [
           {
             feedbackId: 'brightness_match',
-            options: { screenId, brightness: pct },
+            options: { screenId, brightness: String(pct) },
             style: { bgcolor: combineRgb(0, 255, 0), color: combineRgb(0, 0, 0) },
           },
         ],

--- a/src/upgrades.js
+++ b/src/upgrades.js
@@ -27,4 +27,32 @@ export const upgradeScripts = [
     }
     return result;
   },
+  // Migrate from offline_mode checkbox to host-based offline detection
+  function (_context, props) {
+    const result = {
+      updatedConfig: null,
+      updatedActions: [],
+      updatedFeedbacks: [],
+    };
+
+    if (props.config) {
+      const config = props.config;
+
+      // If old offline_mode was enabled and a host was set,
+      // clear the host so the module stays in offline mode
+      if (config.offline_mode === true && config.host) {
+        result.updatedConfig = {
+          ...config,
+          host: '',
+        };
+        delete result.updatedConfig.offline_mode;
+      } else if (config.offline_mode !== undefined) {
+        // Just remove the old offline_mode field
+        result.updatedConfig = { ...config };
+        delete result.updatedConfig.offline_mode;
+      }
+    }
+
+    return result;
+  },
 ];

--- a/utils/constant.js
+++ b/utils/constant.js
@@ -37,6 +37,8 @@ export const ACTIONS_CMD = {
   layer_frz: 'W0509',
   /** 屏幕亮度调节 */
   apply_screen_brightness: 'W0410',
+  /** 保存屏幕亮度到接收卡 */
+  save_screen_brightness: 'W0417',
   /**切源 */
   source_switch: 'W0506',
   /**输出列表 */
@@ -53,6 +55,8 @@ export const ACTIONS_CMD = {
   get_device_init_status: 'R0118',
   /** 设备心跳协议 */
   device_heartbeat: 'W0120',
+  /** 全局黑屏 */
+  blackout: 'W0700',
 };
 
 export const SCREEN_COUNT_H = 40;

--- a/utils/index.js
+++ b/utils/index.js
@@ -51,7 +51,7 @@ export const sendUDPRequest = (instance, cmd, params = {}) => {
     instance.on('udp_response', responseHandler);
 
     // 发送UDP请求
-    instance.udp.send(command);
+    instance.safeSend(command);
   });
 };
 

--- a/utils/index.js
+++ b/utils/index.js
@@ -114,8 +114,8 @@ export const sendUDPRequestsAll = async (instance, requests) => {
 /** 生成屏幕的变量 */
 export const formatScreenVariable = (list) => {
   const screensArr = list.map((item) => ({
-    variableId: `screenId_${item.screenId}`,
-    name: `Screen ID: ${item.screenId}`,
+    variableId: `screen_${item.screenId + 1}`,
+    name: `Screen ${item.screenId + 1}`,
     value: item.name,
   }));
   const screensObj = {};
@@ -134,10 +134,10 @@ export const formatLayerVariable = (screenList) => {
   const layersObj = {};
   screenList?.forEach((screen) => {
     (screen.layers || []).forEach((layer) => {
-      const variableId = `screenId_${screen.screenId}_layerId_${layer.layerId}`;
+      const variableId = `screen_${screen.screenId + 1}_layer_${layer.layerId + 1}`;
       layersArr.push({
         variableId,
-        name: `Layer ID: ${variableId}`,
+        name: `Screen ${screen.screenId + 1} Layer ${layer.layerId + 1}`,
         value: layer.name,
       });
       layersObj[variableId] = layer.name;
@@ -155,10 +155,10 @@ export const formatPresetVariable = (screenList) => {
   const presetsObj = {};
   screenList?.forEach((screen) => {
     (screen.presets || []).forEach((preset) => {
-      const variableId = `screenId_${screen.screenId}_presetId_${preset.presetId}`;
+      const variableId = `screen_${screen.screenId + 1}_preset_${preset.presetId + 1}`;
       presetsArr.push({
         variableId,
-        name: `Preset ID: ${variableId}`,
+        name: `Screen ${screen.screenId + 1} Preset ${preset.presetId + 1}`,
         value: preset.name,
       });
       presetsObj[variableId] = preset.name;
@@ -173,8 +173,8 @@ export const formatPresetVariable = (screenList) => {
 export const formatPresetCollectionVariable = (presetCollectionList) => {
   const presetCollectionVariables =
     presetCollectionList?.map(({ name, presetCollectionId }) => ({
-      variableId: `presetCollectionId_${presetCollectionId}`,
-      name: `Preset Group: ${presetCollectionId}`,
+      variableId: `presetCollectionId_${presetCollectionId + 1}`,
+      name: `Preset Group ${presetCollectionId + 1}`,
       value: name,
     })) || [];
   const presetCollectionVariableObj = {};
@@ -190,8 +190,8 @@ export const formatPresetCollectionVariable = (presetCollectionList) => {
 export const formatSourceVariable = (sourceList) => {
   const sourceVariables =
     sourceList?.map(({ name, inputId, cropId }) => ({
-      variableId: `source_${inputId}_${cropId}`,
-      name: `Source: ${inputId}_${cropId}`,
+      variableId: `source_${inputId + 1}_${cropId}`,
+      name: `Source ${inputId + 1}`,
       value: name,
     })) || [];
   const sourceVariableObj = {};

--- a/utils/request.js
+++ b/utils/request.js
@@ -9,13 +9,13 @@ export const getPresetList = (instance, screenId) => {
     param2: 1,
     param3: 0,
   });
-  instance.udp.send(command);
+  instance.safeSend(command);
 };
 /** 获取屏幕列表 */
 export const getScreenList = (instance) => {
   instance.log('debug', 'getScreenList');
   const command = handleParams(ACTIONS_CMD['get_screen_list']);
-  instance.udp.send(command);
+  instance.safeSend(command);
 };
 /** 获取图层列表 */
 export const getLayerList = (instance, screenId) => {
@@ -24,7 +24,7 @@ export const getLayerList = (instance, screenId) => {
     param0: 0,
     param1: screenId,
   });
-  instance.udp.send(command);
+  instance.safeSend(command);
 };
 
 /** 获取场景组列表 */
@@ -33,7 +33,7 @@ export const getPresetCollectionList = (instance) => {
   const command = handleParams(ACTIONS_CMD['get_preset_collection_list'], {
     param0: 0,
   });
-  instance.udp.send(command);
+  instance.safeSend(command);
 };
 
 /** 获取输入源列表 */
@@ -44,7 +44,7 @@ export const getInputList = (instance) => {
     //1获取输入详情，0不获取
     param1: 1,
   });
-  instance.udp.send(command);
+  instance.safeSend(command);
 };
 
 /** 分页获取输入源列表，直到取完为止，返回合并的 inputs 数组 */
@@ -56,7 +56,7 @@ export const getInputListSimplify = async (instance) => {
     param2: 0,
     param3: 0,
   });
-  instance.udp.send(command);
+  instance.safeSend(command);
 };
 
 /** 应用PGM PVW 上屏 */
@@ -67,7 +67,7 @@ export const applyPgmOrPvw = (instance, { enNonTime, manualPlay, screenId }) => 
     manualPlay,
     screenId,
   });
-  instance.udp.send(command);
+  instance.safeSend(command);
 };
 
 export const getScreenDetails = (instance, screenId) => {
@@ -75,7 +75,7 @@ export const getScreenDetails = (instance, screenId) => {
     param0: 0,
     param1: screenId,
   });
-  instance.udp.send(command);
+  instance.safeSend(command);
 };
 
 /** 应用场景组 */
@@ -84,21 +84,21 @@ export const applyPresetCollection = (instance, { presetCollectionId }) => {
   const command = handleParams(ACTIONS_CMD.apply_preset_collection_list, {
     presetCollectionId,
   });
-  instance.udp.send(command);
+  instance.safeSend(command);
 };
 
 /** 黑屏*/
 export const blackScreen = (instance, param) => {
   instance.log('info', 'blackScreen');
   const command = handleParams(ACTIONS_CMD.black_screen, param);
-  instance.udp.send(command);
+  instance.safeSend(command);
 };
 
 /** 音量静音 */
 export const volumeMute = (instance, params) => {
   instance.log('info', 'volumeMute');
   const command = handleParams(ACTIONS_CMD.volume_switch, params);
-  instance.udp.send(command);
+  instance.safeSend(command);
 };
 
 /**输出列表 */
@@ -108,7 +108,7 @@ export const getOutputList = (instance) => {
     param0: 0,
     param1: 1,
   });
-  instance.udp.send(command);
+  instance.safeSend(command);
 };
 
 /**测试画面开关 */
@@ -121,7 +121,7 @@ export const testPatternSwitch = (instance, { bright, grid, outputId, speed, tes
     speed,
     testPattern,
   });
-  instance.udp.send(command);
+  instance.safeSend(command);
 };
 
 /**输出接口详情 */
@@ -130,5 +130,5 @@ export const getOutputDetails = (instance, outputId) => {
   const command = handleParams(ACTIONS_CMD.get_output_details, {
     outputId,
   });
-  instance.udp.send(command);
+  instance.safeSend(command);
 };


### PR DESCRIPTION
## Summary

This PR brings several significant feature additions to the Novastar H Series splicer module, all tested against live hardware (H2/H5/H9/H15 class) and validated against **Novastar H Series Control Protocol V1.0.19**.

It targets Companion 4.2 (keeps `@companion-module/base ~1.5.1`). A companion PR against the `@companion-module/base ~2.0.0` migration (Companion 4.3+) is forthcoming from `feat/companion-4.3`.

## What's new

### Offline Programming Mode
- New **Offline Programming Mode** toggle in config. When enabled, the module reports `Ok` without a device connected and synthesizes a virtual screen/layer/preset tree from the configured `screenCount` / `inputCardCount`.
- Lets operators build and rehearse entire shows before hardware arrives on-site.
- Cleanly tears down synthetic state on toggle-off; variables/feedbacks stay live.

### Per-screen "direct" state & actions
- New `enhancedState` per-screen store for brightness, frozen, FTB, BKG, OSD text/image, test pattern.
- New **direct** action variants (`freeze_direct`, `ftb_direct`, `bkg_direct`, `osd_direct`, `test_pattern_direct`, `brightness_add_direct`, `brightness_minus_direct`) that target a chosen screen without requiring a prior `select_screen`.
- Matching **direct feedbacks** (`frozen_direct`, `ftb_direct`, `bkg_direct`, `osd_text_direct`, `osd_image_direct`, `test_pattern_direct`, `brightness_match`) + `${screen_N}_*` variables so button colors reflect real per-screen state.
- Optimistic local state update from action callbacks → instant visual feedback, then R0401 reconciliation.

### Absolute brightness with variable support
- New `set_brightness` action (W0410) that accepts a variable-enabled value 0–100.

### Input signal tracking
- Polls **R0103** (`Get Connector Information`) per slot × connector on each poll tick; exposes `input_N_M_signal` variables (`Active` / `No Signal`) and an `input_signal` boolean feedback.
- Per protocol V1.0.19 §4.3.3, `iSignal` values `0` and `2` are both treated as inactive; `1` is active.
- UDP-gated on `connectStatus` so no spurious traffic while offline.

### Safety / stability
- New `safeSend` wrapper replaces raw `udp.send` throughout — catches transport errors and flips status to `ConnectionFailure` (or `Ok` in offline mode) instead of crashing the instance.
- Heartbeat / init-status reconciliation cleaned up.

### Upstream sync
- Merges all Dependabot bumps up to #34 (tar, flatted, picomatch, axios, follow-redirects).

## Regression audit

I ran a function-by-function comparison of every upstream action, feedback, preset, and `UDPResponse` case against this branch — **no removals, no signature changes**. All upstream callbacks are preserved; the only behavioral change is that they now use `safeSend` and early-return on `!connectStatus`, which was required to make offline mode safe.

## Test plan

- [x] Tested against a live H5 splicer (4 input cards, 4 screens)
- [x] Offline mode: toggle on with no host → variables/feedbacks populate; toggle off → clears cleanly
- [x] Direct actions + feedbacks per screen: brightness +/-, freeze, FTB, BKG, OSD, test pattern
- [x] Input signal feedback flips state within one poll cycle on cable pull/insert
- [x] Existing presets (PGM/PVW, Take, load preset, preset groups, screen/layer select) execute identically to upstream
- [x] R0103 indexing verified against protocol V1.0.19 (0-indexed slot, connector 0-3)

Happy to split this into smaller PRs if the maintainers prefer — the four feature areas (offline mode, direct actions, input signal, safeSend) are independently reviewable.