### PR TITLE
Add safeSend() wrapper so UDP transport errors don't crash the instance

### DIFF
--- a/src/actions.js
+++ b/src/actions.js
@@ -118,7 +118,7 @@ export const getActions = (instance) => {
           screenId,
           presetId,
         });
-        instance.udp.send(command);
+        instance.safeSend(command);
       },
     },
     // 发送命令
@@ -141,7 +141,7 @@ export const getActions = (instance) => {
         } = event;
         try {
           const params = Buffer.from(command);
-          instance.udp.send(params);
+          instance.safeSend(params);
         } catch (error) {
           instance.log('error', 'send command error');
         }
@@ -360,7 +360,7 @@ export const getActions = (instance) => {
         }
         instance.selectedScreenList.forEach((screenId) => {
           instance.log('debug', { screenId, enable });
-          instance.udp.send(handleParams(ACTIONS_CMD.screen_frz, { screenId, enable }));
+          instance.safeSend(handleParams(ACTIONS_CMD.screen_frz, { screenId, enable }));
         });
       },
     },
@@ -379,7 +379,7 @@ export const getActions = (instance) => {
             volume: volume,
             isMute: 0,
           });
-          instance.udp.send(command);
+          instance.safeSend(command);
         });
       },
     },
@@ -398,7 +398,7 @@ export const getActions = (instance) => {
             volume: volume,
             isMute: 0,
           });
-          instance.udp.send(command);
+          instance.safeSend(command);
         });
       },
     },
@@ -416,7 +416,7 @@ export const getActions = (instance) => {
             screenId,
             brightness: brightness,
           });
-          instance.udp.send(command);
+          instance.safeSend(command);
         });
       },
     },
@@ -434,7 +434,7 @@ export const getActions = (instance) => {
             screenId,
             brightness: brightness,
           });
-          instance.udp.send(command);
+          instance.safeSend(command);
         });
       },
     },
@@ -470,7 +470,7 @@ export const getActions = (instance) => {
           instance.log('error', 'Please select a layer');
           return;
         }
-        instance.udp.send(
+        instance.safeSend(
           handleParams(ACTIONS_CMD.layer_frz, {
             layerId: instance.selectedLayerInfo.layerId,
             screenId: instance.selectedLayerInfo.screenId,
@@ -499,7 +499,7 @@ export const getActions = (instance) => {
         instance.selectedSourceId = id;
         instance.checkFeedbacks();
         if (!source || !instance.selectedLayerInfo) return;
-        instance.udp.send(
+        instance.safeSend(
           handleParams(ACTIONS_CMD.source_switch, {
             inputId: source.inputId,
             sourceType: source.sourceType,

--- a/src/main.js
+++ b/src/main.js
@@ -86,6 +86,23 @@ class ModuleInstance extends InstanceBase {
     this.selectedPresetInfo = null;
   }
 
+  /**
+   * Send data via UDP with error handling so transport errors don't
+   * crash the instance. Flips status to ConnectionFailure on failure.
+   */
+  safeSend(data) {
+    if (!this.udp) {
+      this.log('debug', 'safeSend: no UDP socket');
+      return;
+    }
+    try {
+      this.udp.send(data);
+    } catch (err) {
+      this.log('warn', `UDP send error: ${err.message}`);
+      this.updateStatus(InstanceStatus.ConnectionFailure);
+    }
+  }
+
   handleGetAllData() {
     this.getAllData();
     this.updateAll();
@@ -324,7 +341,7 @@ class ModuleInstance extends InstanceBase {
   sendInitStatusRequest() {
     this.log('debug', 'Sending initial status request...');
     if (this.udp) {
-      this.udp.send(Buffer.from(JSON.stringify([{ cmd: ACTIONS_CMD.get_device_init_status, param0: this.deviceId }])));
+      this.safeSend(Buffer.from(JSON.stringify([{ cmd: ACTIONS_CMD.get_device_init_status, param0: this.deviceId }])));
     }
   }
 
@@ -355,7 +372,7 @@ class ModuleInstance extends InstanceBase {
 
   sendHeartbeat() {
     if (this.udp) {
-      this.udp.send(Buffer.from(JSON.stringify([{ cmd: ACTIONS_CMD.device_heartbeat, deviceId: this.deviceId }])));
+      this.safeSend(Buffer.from(JSON.stringify([{ cmd: ACTIONS_CMD.device_heartbeat, deviceId: this.deviceId }])));
     }
   }
 

--- a/utils/index.js
+++ b/utils/index.js
@@ -51,7 +51,7 @@ export const sendUDPRequest = (instance, cmd, params = {}) => {
     instance.on('udp_response', responseHandler);
 
     // 发送UDP请求
-    instance.udp.send(command);
+    instance.safeSend(command);
   });
 };
 

--- a/utils/request.js
+++ b/utils/request.js
@@ -9,13 +9,13 @@ export const getPresetList = (instance, screenId) => {
     param2: 1,
     param3: 0,
   });
-  instance.udp.send(command);
+  instance.safeSend(command);
 };
 /** 获取屏幕列表 */
 export const getScreenList = (instance) => {
   instance.log('debug', 'getScreenList');
   const command = handleParams(ACTIONS_CMD['get_screen_list']);
-  instance.udp.send(command);
+  instance.safeSend(command);
 };
 /** 获取图层列表 */
 export const getLayerList = (instance, screenId) => {
@@ -24,7 +24,7 @@ export const getLayerList = (instance, screenId) => {
     param0: 0,
     param1: screenId,
   });
-  instance.udp.send(command);
+  instance.safeSend(command);
 };
 
 /** 获取场景组列表 */
@@ -33,7 +33,7 @@ export const getPresetCollectionList = (instance) => {
   const command = handleParams(ACTIONS_CMD['get_preset_collection_list'], {
     param0: 0,
   });
-  instance.udp.send(command);
+  instance.safeSend(command);
 };
 
 /** 获取输入源列表 */
@@ -44,7 +44,7 @@ export const getInputList = (instance) => {
     //1获取输入详情，0不获取
     param1: 1,
   });
-  instance.udp.send(command);
+  instance.safeSend(command);
 };
 
 /** 分页获取输入源列表，直到取完为止，返回合并的 inputs 数组 */
@@ -56,7 +56,7 @@ export const getInputListSimplify = async (instance) => {
     param2: 0,
     param3: 0,
   });
-  instance.udp.send(command);
+  instance.safeSend(command);
 };
 
 /** 应用PGM PVW 上屏 */
@@ -67,7 +67,7 @@ export const applyPgmOrPvw = (instance, { enNonTime, manualPlay, screenId }) => 
     manualPlay,
     screenId,
   });
-  instance.udp.send(command);
+  instance.safeSend(command);
 };
 
 export const getScreenDetails = (instance, screenId) => {
@@ -75,7 +75,7 @@ export const getScreenDetails = (instance, screenId) => {
     param0: 0,
     param1: screenId,
   });
-  instance.udp.send(command);
+  instance.safeSend(command);
 };
 
 /** 应用场景组 */
@@ -84,21 +84,21 @@ export const applyPresetCollection = (instance, { presetCollectionId }) => {
   const command = handleParams(ACTIONS_CMD.apply_preset_collection_list, {
     presetCollectionId,
   });
-  instance.udp.send(command);
+  instance.safeSend(command);
 };
 
 /** 黑屏*/
 export const blackScreen = (instance, param) => {
   instance.log('info', 'blackScreen');
   const command = handleParams(ACTIONS_CMD.black_screen, param);
-  instance.udp.send(command);
+  instance.safeSend(command);
 };
 
 /** 音量静音 */
 export const volumeMute = (instance, params) => {
   instance.log('info', 'volumeMute');
   const command = handleParams(ACTIONS_CMD.volume_switch, params);
-  instance.udp.send(command);
+  instance.safeSend(command);
 };
 
 /**输出列表 */
@@ -108,7 +108,7 @@ export const getOutputList = (instance) => {
     param0: 0,
     param1: 1,
   });
-  instance.udp.send(command);
+  instance.safeSend(command);
 };
 
 /**测试画面开关 */
@@ -121,7 +121,7 @@ export const testPatternSwitch = (instance, { bright, grid, outputId, speed, tes
     speed,
     testPattern,
   });
-  instance.udp.send(command);
+  instance.safeSend(command);
 };
 
 /**输出接口详情 */
@@ -130,5 +130,5 @@ export const getOutputDetails = (instance, outputId) => {
   const command = handleParams(ACTIONS_CMD.get_output_details, {
     outputId,
   });
-  instance.udp.send(command);
+  instance.safeSend(command);
 };


### PR DESCRIPTION
## Summary

Tiny, foundational PR. Replaces every raw `instance.udp.send(...)` /
`this.udp.send(...)` with a new `safeSend(data)` method on
`ModuleInstance`. Split out from #35 per @NovaStar-Service's request.

**Prerequisite for the rest of the split series** (#input-signal,
#direct-actions, #offline-mode) — those branches don't call safeSend
directly, but their new send sites are easier to audit once every
existing send is already wrapped.

## What changes

- `safeSend(data)` in `src/main.js`:
  - no-ops with a debug log if the socket is gone, instead of throwing on `this.udp.send()` null deref
  - catches synchronous transport errors, logs a warning, and flips status to `ConnectionFailure`
- Sweep across `src/actions.js`, `src/main.js`, `utils/index.js`, `utils/request.js`: every raw `.udp.send(...)` becomes `.safeSend(...)`

Strict superset of upstream behavior on the success path — the only user-visible change is that instances no longer die on transient UDP errors.

## Test plan

- [x] Tested against live H5 splicer — no regression on normal operation
- [x] Pulled network cable mid-session: upstream `main` crashes the instance; this branch logs a warning and marks `ConnectionFailure`
- [x] `node -c` syntax check on every touched file