### PR TITLE
Add input signal tracking via R0103 — new input_N_M_signal variables and input_signal feedback

### DIFF
--- a/src/feedbacks.js
+++ b/src/feedbacks.js
@@ -178,6 +178,37 @@ export const getFeedbacks = (instance) => {
         }
       },
     },
+    input_signal: {
+      type: 'boolean',
+      name: 'Input Signal Active',
+      description: 'True when the selected input connector has an active signal (R0103 iSignal=1).',
+      defaultStyle: {
+        bgcolor: combineRgb(0, 200, 0),
+        color: combineRgb(255, 255, 255),
+      },
+      options: [
+        {
+          type: 'dropdown',
+          label: 'Input',
+          id: 'inputKey',
+          default: 'input_1_1',
+          choices: (() => {
+            const choices = [];
+            const inputCardCount = instance.config?.inputCardCount || 1;
+            for (let slot = 0; slot < inputCardCount; slot++) {
+              for (let conn = 0; conn < 4; conn++) {
+                choices.push({
+                  id: `input_${slot + 1}_${conn + 1}`,
+                  label: `Input ${slot + 1}-${conn + 1}`,
+                });
+              }
+            }
+            return choices;
+          })(),
+        },
+      ],
+      callback: (event) => instance.inputSignalState[event.options.inputKey] === true,
+    },
     preset_loaded: {
       type: 'boolean',
       name: 'Load Preset',

--- a/src/main.js
+++ b/src/main.js
@@ -84,6 +84,8 @@ class ModuleInstance extends InstanceBase {
     });
     /** 加载的场景信息 */
     this.selectedPresetInfo = null;
+    /** Input signal state — keyed by `input_${slot+1}_${connector+1}` -> boolean */
+    this.inputSignalState = {};
   }
 
   handleGetAllData() {
@@ -120,12 +122,23 @@ class ModuleInstance extends InstanceBase {
     const { presetCollectionVariableDefinitions, presetCollectionDefaultVariableValues } =
       formatPresetCollectionVariable(this.presetCollectionList);
     const { sourceVariableDefinitions, sourceDefaultVariableValues } = formatSourceVariable(this.sourceList);
+
+    // Input signal variables (one per slot×connector based on configured input card count)
+    const inputSignalDefinitions = [];
+    const inputSignalValues = {};
+    for (const [inputKey, hasSignal] of Object.entries(this.inputSignalState)) {
+      const label = inputKey.replace('input_', '').replace('_', '-');
+      inputSignalDefinitions.push({ variableId: `${inputKey}_signal`, name: `Input ${label} Signal` });
+      inputSignalValues[`${inputKey}_signal`] = hasSignal ? 'Active' : 'No Signal';
+    }
+
     this.setVariableDefinitions([
       ...screenVariableDefinitions,
       ...layerVariableDefinitions,
       ...presetVariableDefinitions,
       ...presetCollectionVariableDefinitions,
       ...sourceVariableDefinitions,
+      ...inputSignalDefinitions,
     ]);
     this.setVariableValues({
       ...screenDefaultVariableValues,
@@ -133,6 +146,7 @@ class ModuleInstance extends InstanceBase {
       ...presetDefaultVariableValues,
       ...presetCollectionDefaultVariableValues,
       ...sourceDefaultVariableValues,
+      ...inputSignalValues,
     });
   }
 
@@ -143,9 +157,38 @@ class ModuleInstance extends InstanceBase {
     getPresetCollectionList(this);
     getOutputList(this);
     getInputListSimplify(this);
+    // Poll input signal state (R0103) for each input connector
+    this.pollInputSignals();
+  }
+
+  /**
+   * Query R0103 (Get Connector Information) for every input slot × connector.
+   * Per Novastar H Series Control Protocol V1.0.19 §4.3.3, each input card
+   * exposes 4 connectors indexed 0–3. The response's `iSignal` field is 1
+   * when an active signal is present (values 0 and 2 both mean inactive).
+   */
+  pollInputSignals() {
+    if (!this.udp) return;
+    const inputCardCount = this.config.inputCardCount || 1;
+    for (let slot = 0; slot < inputCardCount; slot++) {
+      for (let connector = 0; connector < 4; connector++) {
+        const cmd = JSON.stringify([{ cmd: 'R0103', param0: 0, param1: slot, param2: connector }]);
+        try {
+          this.udp.send(Buffer.from(cmd));
+        } catch (err) {
+          this.log('debug', `R0103 send failed: ${err.message}`);
+        }
+      }
+    }
   }
 
   getConfigFields() {
+    // Input card count dropdown (1–40), each card has 4 connectors
+    const inputCardChoices = [];
+    for (let i = 1; i <= 40; i++) {
+      inputCardChoices.push({ id: i, label: `${i} (${i * 4} inputs)` });
+    }
+
     return [
       {
         type: 'static-text',
@@ -169,6 +212,15 @@ class ModuleInstance extends InstanceBase {
         width: 6,
         default: '6000',
         regex: Regex.PORT,
+      },
+      {
+        type: 'dropdown',
+        id: 'inputCardCount',
+        label: 'Number of Input Cards',
+        width: 6,
+        default: 1,
+        choices: inputCardChoices,
+        tooltip: 'Number of input cards installed (each card has 4 connectors). Drives R0103 polling for input_N_M_signal variables and the input_signal feedback.',
       },
     ];
   }
@@ -393,6 +445,20 @@ class ModuleInstance extends InstanceBase {
         this.handleInitStatusResponse(res.data.rate);
         break;
       default:
+        // R0103 (Get Connector Information) — input signal state
+        if (res.cmd === 'R0103' && res.ack === 'Ok') {
+          const slotId = res.data?.slotId ?? 0;
+          const interfaceId = res.data?.interfaceId ?? 0;
+          // Protocol V1.0.19 §4.3.3: iSignal=1 active; 0 (no source) and 2 (disconnected) both inactive
+          const hasSignal = res.data?.iSignal === 1;
+          const inputKey = `input_${slotId + 1}_${interfaceId + 1}`;
+          const prev = this.inputSignalState[inputKey];
+          this.inputSignalState[inputKey] = hasSignal;
+          this.setVariableValues({ [`${inputKey}_signal`]: hasSignal ? 'Active' : 'No Signal' });
+          if (prev !== hasSignal) {
+            this.checkFeedbacks('input_signal');
+          }
+        }
         break;
     }
     this.updateAll();


### PR DESCRIPTION
## Summary

Surfaces per-connector input signal state on H Series splicers. Split
out from #35 per @NovaStar-Service's request.

Operators currently have no way to drive a button's color/behavior
from "is cable X plugged in and carrying signal" — this adds that
capability cleanly via a new variable family and a boolean feedback.

## What's new

- **Polls R0103** (`Get Connector Information`) for each input slot × connector on every `getAllData` tick. Per Novastar H Series Control Protocol V1.0.19 §4.3.3:
  - `iSignal = 1` → active signal ("Active")
  - `iSignal = 0` (no source) or `iSignal = 2` (disconnected) → no active signal ("No Signal")
  - Each input card exposes 4 connectors (0–3)
- **New variables**: `input_N_M_signal` (where N = slot 1-based, M = connector 1-based), values `"Active"` / `"No Signal"`
- **New feedback**: `input_signal` (boolean) with a per-connector dropdown
- **New config field**: `Number of Input Cards` (1–40, each card has 4 connectors) so polling and feedback choices match the installed hardware

## Regression scope

No existing actions, feedbacks, or handlers are modified. R0103 responses are picked up via a **new branch in the `UDPResponse` default case** — upstream previously ignored them.

## Test plan

- [x] Live H5 splicer, cable pull/insert reflects within one poll cycle
- [x] Multi-card (1×, 2×, 4× input card) config renders correct connector dropdown
- [x] R0103 indexing verified verbatim against protocol V1.0.19 (slot 0-indexed, connector 0–3)