### PR TITLE
Add per-screen direct actions and feedbacks (no more select_screen → change → deselect)

### DIFF
--- a/src/actions.js
+++ b/src/actions.js
@@ -402,6 +402,145 @@ export const getActions = (instance) => {
         });
       },
     },
+    // ==================== Direct per-screen actions ====================
+    // One-click, screen-targeted variants that don't require a prior select_screen.
+    // Each updates `enhancedState` optimistically for instant feedback then sends
+    // the protocol command. Device truth reconciles on the next R0401 details poll.
+    brightness_add_direct: {
+      name: 'Brightness + (Direct)',
+      description: 'Increase brightness by 1% on a specific screen (no select_screen needed).',
+      options: [
+        { type: 'dropdown', label: 'Screen', id: 'screenId', default: screenListDropDown[0]?.id ?? null, choices: screenListDropDown },
+      ],
+      callback: async (event) => {
+        const screenId = event.options.screenId;
+        const details = instance.screenList?.find((s) => s.screenId === screenId)?.details;
+        if (!details) return;
+        const brightness = Math.min((details.brightness ?? 100) + 1, 100);
+        details.brightness = brightness;
+        instance.updateEnhancedFromAction(screenId, 'brightness', brightness);
+        if (!instance.udp) return;
+        instance.udp.send(handleParams(ACTIONS_CMD.apply_screen_brightness, { screenId, brightness }));
+      },
+    },
+    brightness_minus_direct: {
+      name: 'Brightness - (Direct)',
+      description: 'Decrease brightness by 1% on a specific screen (no select_screen needed).',
+      options: [
+        { type: 'dropdown', label: 'Screen', id: 'screenId', default: screenListDropDown[0]?.id ?? null, choices: screenListDropDown },
+      ],
+      callback: async (event) => {
+        const screenId = event.options.screenId;
+        const details = instance.screenList?.find((s) => s.screenId === screenId)?.details;
+        if (!details) return;
+        const brightness = Math.max((details.brightness ?? 100) - 1, 0);
+        details.brightness = brightness;
+        instance.updateEnhancedFromAction(screenId, 'brightness', brightness);
+        if (!instance.udp) return;
+        instance.udp.send(handleParams(ACTIONS_CMD.apply_screen_brightness, { screenId, brightness }));
+      },
+    },
+    set_brightness: {
+      name: 'Set Brightness',
+      description: 'Set brightness of a specific screen to an absolute value (0-100). Supports variables.',
+      options: [
+        { type: 'dropdown', label: 'Screen', id: 'screenId', default: screenListDropDown[0]?.id ?? null, choices: screenListDropDown },
+        { type: 'textinput', label: 'Brightness (0-100)', id: 'brightness', default: '100', useVariables: true },
+      ],
+      callback: async (event) => {
+        const screenId = event.options.screenId;
+        const raw = await instance.parseVariablesInString(String(event.options.brightness));
+        const brightness = Math.max(0, Math.min(100, Math.round(Number(raw))));
+        if (isNaN(brightness)) {
+          instance.log('warn', `set_brightness: invalid value "${raw}"`);
+          return;
+        }
+        const details = instance.screenList?.find((s) => s.screenId === screenId)?.details;
+        if (details) details.brightness = brightness;
+        instance.updateEnhancedFromAction(screenId, 'brightness', brightness);
+        if (!instance.udp) return;
+        instance.udp.send(handleParams(ACTIONS_CMD.apply_screen_brightness, { screenId, brightness }));
+      },
+    },
+    freeze_direct: {
+      name: 'Freeze (Direct)',
+      description: 'Enable or disable freeze on a specific screen.',
+      options: [
+        { type: 'dropdown', label: 'Screen', id: 'screenId', default: screenListDropDown[0]?.id ?? null, choices: screenListDropDown },
+        { type: 'dropdown', label: 'State', id: 'state', default: 1, choices: [{ id: 1, label: 'Enable' }, { id: 0, label: 'Disable' }] },
+      ],
+      callback: async (event) => {
+        const screenId = event.options.screenId;
+        const enable = parseInt(event.options.state);
+        instance.updateEnhancedFromAction(screenId, 'frozen', enable === 1);
+        if (!instance.udp) return;
+        instance.udp.send(handleParams(ACTIONS_CMD.screen_frz, { screenId, enable }));
+      },
+    },
+    ftb_direct: {
+      name: 'FTB (Direct)',
+      description: 'Enable or disable Fade-to-Black on a specific screen.',
+      options: [
+        { type: 'dropdown', label: 'Screen', id: 'screenId', default: screenListDropDown[0]?.id ?? null, choices: screenListDropDown },
+        { type: 'dropdown', label: 'State', id: 'state', default: 1, choices: [{ id: 1, label: 'Enable' }, { id: 0, label: 'Disable' }] },
+      ],
+      callback: async (event) => {
+        const screenId = event.options.screenId;
+        const enable = parseInt(event.options.state);
+        instance.updateEnhancedFromAction(screenId, 'ftb', enable === 1);
+        if (!instance.udp) return;
+        // Protocol: blackout 0 = FTB on, 1 = FTB off (inverted)
+        instance.udp.send(handleParams(ACTIONS_CMD.black_screen, { screenId, type: enable === 1 ? 0 : 1 }));
+      },
+    },
+    bkg_direct: {
+      name: 'BKG (Direct)',
+      description: 'Enable or disable BKG on a specific screen.',
+      options: [
+        { type: 'dropdown', label: 'Screen', id: 'screenId', default: screenListDropDown[0]?.id ?? null, choices: screenListDropDown },
+        { type: 'dropdown', label: 'State', id: 'state', default: 1, choices: [{ id: 1, label: 'Enable' }, { id: 0, label: 'Disable' }] },
+      ],
+      callback: async (event) => {
+        const screenId = event.options.screenId;
+        const enable = parseInt(event.options.state);
+        instance.updateEnhancedFromAction(screenId, 'bkg', enable === 1);
+        if (!instance.udp) return;
+        instance.udp.send(handleParams(ACTIONS_CMD.bkg_switch, { screenId, enable, bkgId: 0 }));
+      },
+    },
+    osd_direct: {
+      name: 'OSD (Direct)',
+      description: 'Enable or disable OSD on a specific screen.',
+      options: [
+        { type: 'dropdown', label: 'Screen', id: 'screenId', default: screenListDropDown[0]?.id ?? null, choices: screenListDropDown },
+        { type: 'dropdown', label: 'Type', id: 'osdType', default: 'text', choices: [{ id: 'text', label: 'OSD Text' }, { id: 'image', label: 'OSD Image' }] },
+        { type: 'dropdown', label: 'State', id: 'state', default: 1, choices: [{ id: 1, label: 'Enable' }, { id: 0, label: 'Disable' }] },
+      ],
+      callback: async (event) => {
+        const screenId = event.options.screenId;
+        const enable = parseInt(event.options.state);
+        const osdType = event.options.osdType;
+        instance.updateEnhancedFromAction(screenId, osdType === 'image' ? 'osdImage' : 'osdText', enable === 1);
+        if (!instance.udp) return;
+        instance.udp.send(handleParams(ACTIONS_CMD.osd_switch, { screenId, Osd: { enable } }));
+      },
+    },
+    test_pattern_direct: {
+      name: 'Test Pattern (Direct)',
+      description: 'Enable or disable test pattern on a specific screen.',
+      options: [
+        { type: 'dropdown', label: 'Screen', id: 'screenId', default: screenListDropDown[0]?.id ?? null, choices: screenListDropDown },
+        { type: 'dropdown', label: 'State', id: 'state', default: 1, choices: [{ id: 1, label: 'Enable' }, { id: 0, label: 'Disable' }] },
+      ],
+      callback: async (event) => {
+        const screenId = event.options.screenId;
+        const enable = parseInt(event.options.state);
+        instance.updateEnhancedFromAction(screenId, 'testPattern', enable === 1);
+        if (!instance.udp) return;
+        instance.udp.send(handleParams(ACTIONS_CMD.test_pattern_switch, { screenId, enable, type: 0 }));
+      },
+    },
+    // ==================== End direct per-screen actions ====================
     screen_brightness_add: {
       name: 'Screen Brightness Add',
       description: 'Increase the brightness of the screen loaded by the selected sending card.',

--- a/src/feedbacks.js
+++ b/src/feedbacks.js
@@ -178,6 +178,85 @@ export const getFeedbacks = (instance) => {
         }
       },
     },
+    // ==================== Direct per-screen feedbacks ====================
+    // Boolean feedbacks that read the enhancedState for a specific screen.
+    // Let operators show live state on per-screen buttons without requiring
+    // the screen to be selected first.
+    brightness_match: {
+      type: 'boolean',
+      name: 'Brightness Matches Value (Direct)',
+      description: 'True when the selected screen brightness equals the given value.',
+      defaultStyle: { bgcolor: combineRgb(0, 200, 0), color: combineRgb(255, 255, 255) },
+      options: [
+        { type: 'dropdown', label: 'Screen', id: 'screenId', default: screenListDropDown[0]?.id ?? null, choices: screenListDropDown },
+        { type: 'number', label: 'Value (0-100)', id: 'value', default: 100, min: 0, max: 100 },
+      ],
+      callback: (event) => {
+        const s = instance.enhancedState?.screens[event.options.screenId];
+        return s ? s.brightness === event.options.value : false;
+      },
+    },
+    frozen_direct: {
+      type: 'boolean',
+      name: 'Freeze State (Direct)',
+      description: 'True when the specific screen is frozen.',
+      defaultStyle: { bgcolor: combineRgb(0, 200, 255), color: combineRgb(0, 0, 0) },
+      options: [
+        { type: 'dropdown', label: 'Screen', id: 'screenId', default: screenListDropDown[0]?.id ?? null, choices: screenListDropDown },
+      ],
+      callback: (event) => instance.enhancedState?.screens[event.options.screenId]?.frozen === true,
+    },
+    ftb_direct: {
+      type: 'boolean',
+      name: 'FTB State (Direct)',
+      description: 'True when FTB is active on the specific screen.',
+      defaultStyle: { bgcolor: combineRgb(200, 0, 0), color: combineRgb(255, 255, 255) },
+      options: [
+        { type: 'dropdown', label: 'Screen', id: 'screenId', default: screenListDropDown[0]?.id ?? null, choices: screenListDropDown },
+      ],
+      callback: (event) => instance.enhancedState?.screens[event.options.screenId]?.ftb === true,
+    },
+    bkg_direct: {
+      type: 'boolean',
+      name: 'BKG State (Direct)',
+      description: 'True when BKG is enabled on the specific screen.',
+      defaultStyle: { bgcolor: combineRgb(0, 200, 0), color: combineRgb(0, 0, 0) },
+      options: [
+        { type: 'dropdown', label: 'Screen', id: 'screenId', default: screenListDropDown[0]?.id ?? null, choices: screenListDropDown },
+      ],
+      callback: (event) => instance.enhancedState?.screens[event.options.screenId]?.bkg === true,
+    },
+    osd_text_direct: {
+      type: 'boolean',
+      name: 'OSD Text State (Direct)',
+      description: 'True when OSD Text is enabled on the specific screen.',
+      defaultStyle: { bgcolor: combineRgb(0, 200, 0), color: combineRgb(0, 0, 0) },
+      options: [
+        { type: 'dropdown', label: 'Screen', id: 'screenId', default: screenListDropDown[0]?.id ?? null, choices: screenListDropDown },
+      ],
+      callback: (event) => instance.enhancedState?.screens[event.options.screenId]?.osdText === true,
+    },
+    osd_image_direct: {
+      type: 'boolean',
+      name: 'OSD Image State (Direct)',
+      description: 'True when OSD Image is enabled on the specific screen.',
+      defaultStyle: { bgcolor: combineRgb(0, 200, 0), color: combineRgb(0, 0, 0) },
+      options: [
+        { type: 'dropdown', label: 'Screen', id: 'screenId', default: screenListDropDown[0]?.id ?? null, choices: screenListDropDown },
+      ],
+      callback: (event) => instance.enhancedState?.screens[event.options.screenId]?.osdImage === true,
+    },
+    test_pattern_direct: {
+      type: 'boolean',
+      name: 'Test Pattern State (Direct)',
+      description: 'True when test pattern is enabled on the specific screen.',
+      defaultStyle: { bgcolor: combineRgb(255, 200, 0), color: combineRgb(0, 0, 0) },
+      options: [
+        { type: 'dropdown', label: 'Screen', id: 'screenId', default: screenListDropDown[0]?.id ?? null, choices: screenListDropDown },
+      ],
+      callback: (event) => instance.enhancedState?.screens[event.options.screenId]?.testPattern === true,
+    },
+    // ==================== End direct per-screen feedbacks ====================
     preset_loaded: {
       type: 'boolean',
       name: 'Load Preset',

--- a/src/main.js
+++ b/src/main.js
@@ -84,6 +84,87 @@ class ModuleInstance extends InstanceBase {
     });
     /** 加载的场景信息 */
     this.selectedPresetInfo = null;
+    /**
+     * Per-screen state for direct actions/feedbacks.
+     * Mirrors device truth (populated from R0401 apply_screen_details) and
+     * accepts optimistic updates from action callbacks for instant feedback.
+     */
+    this.enhancedState = { screens: {} };
+  }
+
+  /** Initialize per-screen enhanced state with defaults */
+  initEnhancedScreen(screenId) {
+    this.enhancedState.screens[screenId] = {
+      brightness: 100,
+      frozen: false,
+      ftb: false,
+      bkg: false,
+      osdText: false,
+      osdImage: false,
+      testPattern: false,
+    };
+  }
+
+  /** Update enhanced state from R0401 screen details response */
+  updateEnhancedFromDetails(screenId, details) {
+    if (!this.enhancedState.screens[screenId]) this.initEnhancedScreen(screenId);
+    const s = this.enhancedState.screens[screenId];
+    if (details.brightness !== undefined) s.brightness = details.brightness;
+    if (details.screenFrz !== undefined) s.frozen = details.screenFrz === 1;
+    // Protocol: blackout 0 = FTB enabled, 1 = FTB disabled (inverted)
+    if (details.blackout !== undefined) s.ftb = details.blackout === 0;
+    if (details.bkgEnable !== undefined) s.bkg = details.bkgEnable === 1;
+    if (details.textOsdEnable !== undefined) s.osdText = details.textOsdEnable === 1;
+    if (details.imgOsdEnable !== undefined) s.osdImage = details.imgOsdEnable === 1;
+  }
+
+  /** Optimistic update from action callback — instant variable + feedback refresh */
+  updateEnhancedFromAction(screenId, property, value) {
+    if (!this.enhancedState.screens[screenId]) this.initEnhancedScreen(screenId);
+    this.enhancedState.screens[screenId][property] = value;
+    const prefix = `screen_${screenId + 1}`;
+    const varMap = {
+      brightness: { key: `${prefix}_brightness`, val: value, feedbacks: ['brightness_match'] },
+      frozen: { key: `${prefix}_frozen`, val: value ? 'On' : 'Off', feedbacks: ['frozen_direct'] },
+      ftb: { key: `${prefix}_ftb`, val: value ? 'On' : 'Off', feedbacks: ['ftb_direct'] },
+      bkg: { key: `${prefix}_bkg`, val: value ? 'On' : 'Off', feedbacks: ['bkg_direct'] },
+      osdText: { key: `${prefix}_osd_text`, val: value ? 'On' : 'Off', feedbacks: ['osd_text_direct'] },
+      osdImage: { key: `${prefix}_osd_image`, val: value ? 'On' : 'Off', feedbacks: ['osd_image_direct'] },
+      testPattern: { key: `${prefix}_test_pattern`, val: value ? 'On' : 'Off', feedbacks: ['test_pattern_direct'] },
+    };
+    if (varMap[property]) {
+      this.setVariableValues({ [varMap[property].key]: varMap[property].val });
+      this.checkFeedbacks(...varMap[property].feedbacks);
+    }
+  }
+
+  /** Build per-screen enhanced variable defs + values */
+  getEnhancedVariables() {
+    const definitions = [];
+    const values = {};
+    for (const [screenIdStr, state] of Object.entries(this.enhancedState.screens)) {
+      const screenId = Number(screenIdStr);
+      const screen = this.screenList.find((s) => s.screenId === screenId);
+      const screenName = screen ? screen.name : `Screen ${screenId + 1}`;
+      const prefix = `screen_${screenId + 1}`;
+      definitions.push(
+        { variableId: `${prefix}_brightness`, name: `${screenName} Brightness` },
+        { variableId: `${prefix}_frozen`, name: `${screenName} Frozen` },
+        { variableId: `${prefix}_ftb`, name: `${screenName} FTB` },
+        { variableId: `${prefix}_bkg`, name: `${screenName} BKG` },
+        { variableId: `${prefix}_osd_text`, name: `${screenName} OSD Text` },
+        { variableId: `${prefix}_osd_image`, name: `${screenName} OSD Image` },
+        { variableId: `${prefix}_test_pattern`, name: `${screenName} Test Pattern` },
+      );
+      values[`${prefix}_brightness`] = state.brightness;
+      values[`${prefix}_frozen`] = state.frozen ? 'On' : 'Off';
+      values[`${prefix}_ftb`] = state.ftb ? 'On' : 'Off';
+      values[`${prefix}_bkg`] = state.bkg ? 'On' : 'Off';
+      values[`${prefix}_osd_text`] = state.osdText ? 'On' : 'Off';
+      values[`${prefix}_osd_image`] = state.osdImage ? 'On' : 'Off';
+      values[`${prefix}_test_pattern`] = state.testPattern ? 'On' : 'Off';
+    }
+    return { definitions, values };
   }
 
   handleGetAllData() {
@@ -120,12 +201,15 @@ class ModuleInstance extends InstanceBase {
     const { presetCollectionVariableDefinitions, presetCollectionDefaultVariableValues } =
       formatPresetCollectionVariable(this.presetCollectionList);
     const { sourceVariableDefinitions, sourceDefaultVariableValues } = formatSourceVariable(this.sourceList);
+    const { definitions: enhancedDefs, values: enhancedVals } = this.getEnhancedVariables();
+
     this.setVariableDefinitions([
       ...screenVariableDefinitions,
       ...layerVariableDefinitions,
       ...presetVariableDefinitions,
       ...presetCollectionVariableDefinitions,
       ...sourceVariableDefinitions,
+      ...enhancedDefs,
     ]);
     this.setVariableValues({
       ...screenDefaultVariableValues,
@@ -133,6 +217,7 @@ class ModuleInstance extends InstanceBase {
       ...presetDefaultVariableValues,
       ...presetCollectionDefaultVariableValues,
       ...sourceDefaultVariableValues,
+      ...enhancedVals,
     });
   }
 
@@ -432,6 +517,8 @@ class ModuleInstance extends InstanceBase {
   dealScreenDetails(data) {
     if (this.screenList) {
       this.screenList.find((screen) => screen.screenId === data.screenId).details = data;
+      // Reconcile enhanced per-screen state from the device truth
+      this.updateEnhancedFromDetails(data.screenId, data);
     }
   }
 


### PR DESCRIPTION
## Summary

This is the biggest UX fix in the split series. Split out from #35 per
@NovaStar-Service's request.

### The problem

Today every screen-scoped toggle in this module (freeze, FTB, BKG, OSD, test pattern, brightness +/-) requires operators to:

1. Press **Select Screen N**
2. Press **Change** (freeze, FTB, brightness, etc.)
3. Press **Deselect Screen N**

If they forget step 3 — which happens constantly under live-show pressure — the next button press hits whichever screen is still selected. This has caused real incidents on real shows. The pattern is also inconsistent with how `select_screen` works for other devices in the Companion ecosystem.

### The fix

Each existing action gets a **direct variant** that takes a `Screen` dropdown as an option and targets that screen exclusively, without touching `selectedScreenList` at all. The existing actions are preserved unchanged — this is purely additive.

## Infrastructure

- **`enhancedState.screens[screenId]`** — per-screen record of brightness, frozen, ftb, bkg, osdText, osdImage, testPattern
- **`updateEnhancedFromDetails(screenId, details)`** — reconciles from R0401 `apply_screen_details` device truth; hooked into the existing `dealScreenDetails` handler (the only change to an existing code path)
- **`updateEnhancedFromAction(screenId, property, value)`** — optimistic write from action callbacks, pushes the matching variable, and checks the direct feedback group for instant button refresh
- **`getEnhancedVariables()`** — `screen_N_{brightness,frozen,ftb,bkg,osd_text,osd_image,test_pattern}` variables

## New actions

- `brightness_add_direct`, `brightness_minus_direct` — per-screen ±1%
- `set_brightness` — absolute 0–100 with variable support
- `freeze_direct`, `ftb_direct`, `bkg_direct`, `osd_direct`, `test_pattern_direct`

## New feedbacks

- `brightness_match`, `frozen_direct`, `ftb_direct`, `bkg_direct`, `osd_text_direct`, `osd_image_direct`, `test_pattern_direct`

## Regression scope

All upstream actions, feedbacks, and handlers are preserved. The only edit to an existing code path is a **one-line addition** in `dealScreenDetails` to also call `updateEnhancedFromDetails` — this only writes to the new `enhancedState`, so upstream behavior is untouched.

## Test plan

- [x] Live H5 splicer: every direct action/feedback verified against device
- [x] Variables populate immediately via optimistic update; R0401 reconciliation overwrites within one poll cycle
- [x] Existing `select_screen → change` pattern continues to work — users can keep their old buttons