### PR TITLE
Add Offline Programming Mode — build shows without the splicer on the network

### DIFF
--- a/src/actions.js
+++ b/src/actions.js
@@ -419,8 +419,8 @@ export const getActions = (instance) => {
         const brightness = Math.min((details.brightness ?? 100) + 1, 100);
         details.brightness = brightness;
         instance.updateEnhancedFromAction(screenId, 'brightness', brightness);
-        if (!instance.udp) return;
-        instance.udp.send(handleParams(ACTIONS_CMD.apply_screen_brightness, { screenId, brightness }));
+        // safeSend guards on missing udp internally
+        instance.safeSend(handleParams(ACTIONS_CMD.apply_screen_brightness, { screenId, brightness }));
       },
     },
     brightness_minus_direct: {
@@ -436,8 +436,8 @@ export const getActions = (instance) => {
         const brightness = Math.max((details.brightness ?? 100) - 1, 0);
         details.brightness = brightness;
         instance.updateEnhancedFromAction(screenId, 'brightness', brightness);
-        if (!instance.udp) return;
-        instance.udp.send(handleParams(ACTIONS_CMD.apply_screen_brightness, { screenId, brightness }));
+        // safeSend guards on missing udp internally
+        instance.safeSend(handleParams(ACTIONS_CMD.apply_screen_brightness, { screenId, brightness }));
       },
     },
     set_brightness: {
@@ -458,8 +458,8 @@ export const getActions = (instance) => {
         const details = instance.screenList?.find((s) => s.screenId === screenId)?.details;
         if (details) details.brightness = brightness;
         instance.updateEnhancedFromAction(screenId, 'brightness', brightness);
-        if (!instance.udp) return;
-        instance.udp.send(handleParams(ACTIONS_CMD.apply_screen_brightness, { screenId, brightness }));
+        // safeSend guards on missing udp internally
+        instance.safeSend(handleParams(ACTIONS_CMD.apply_screen_brightness, { screenId, brightness }));
       },
     },
     freeze_direct: {
@@ -473,8 +473,8 @@ export const getActions = (instance) => {
         const screenId = event.options.screenId;
         const enable = parseInt(event.options.state);
         instance.updateEnhancedFromAction(screenId, 'frozen', enable === 1);
-        if (!instance.udp) return;
-        instance.udp.send(handleParams(ACTIONS_CMD.screen_frz, { screenId, enable }));
+        // safeSend guards on missing udp internally
+        instance.safeSend(handleParams(ACTIONS_CMD.screen_frz, { screenId, enable }));
       },
     },
     ftb_direct: {
@@ -488,9 +488,9 @@ export const getActions = (instance) => {
         const screenId = event.options.screenId;
         const enable = parseInt(event.options.state);
         instance.updateEnhancedFromAction(screenId, 'ftb', enable === 1);
-        if (!instance.udp) return;
+        // safeSend guards on missing udp internally
         // Protocol: blackout 0 = FTB on, 1 = FTB off (inverted)
-        instance.udp.send(handleParams(ACTIONS_CMD.black_screen, { screenId, type: enable === 1 ? 0 : 1 }));
+        instance.safeSend(handleParams(ACTIONS_CMD.black_screen, { screenId, type: enable === 1 ? 0 : 1 }));
       },
     },
     bkg_direct: {
@@ -504,8 +504,8 @@ export const getActions = (instance) => {
         const screenId = event.options.screenId;
         const enable = parseInt(event.options.state);
         instance.updateEnhancedFromAction(screenId, 'bkg', enable === 1);
-        if (!instance.udp) return;
-        instance.udp.send(handleParams(ACTIONS_CMD.bkg_switch, { screenId, enable, bkgId: 0 }));
+        // safeSend guards on missing udp internally
+        instance.safeSend(handleParams(ACTIONS_CMD.bkg_switch, { screenId, enable, bkgId: 0 }));
       },
     },
     osd_direct: {
@@ -521,8 +521,8 @@ export const getActions = (instance) => {
         const enable = parseInt(event.options.state);
         const osdType = event.options.osdType;
         instance.updateEnhancedFromAction(screenId, osdType === 'image' ? 'osdImage' : 'osdText', enable === 1);
-        if (!instance.udp) return;
-        instance.udp.send(handleParams(ACTIONS_CMD.osd_switch, { screenId, Osd: { enable } }));
+        // safeSend guards on missing udp internally
+        instance.safeSend(handleParams(ACTIONS_CMD.osd_switch, { screenId, Osd: { enable } }));
       },
     },
     test_pattern_direct: {
@@ -536,8 +536,8 @@ export const getActions = (instance) => {
         const screenId = event.options.screenId;
         const enable = parseInt(event.options.state);
         instance.updateEnhancedFromAction(screenId, 'testPattern', enable === 1);
-        if (!instance.udp) return;
-        instance.udp.send(handleParams(ACTIONS_CMD.test_pattern_switch, { screenId, enable, type: 0 }));
+        // safeSend guards on missing udp internally
+        instance.safeSend(handleParams(ACTIONS_CMD.test_pattern_switch, { screenId, enable, type: 0 }));
       },
     },
     // ==================== End direct per-screen actions ====================

--- a/src/main.js
+++ b/src/main.js
@@ -256,19 +256,26 @@ class ModuleInstance extends InstanceBase {
     }
 
     this.presetCollectionList = [];
-    // Synthetic input source entries so source dropdowns populate offline
+    // Synthetic input source entries so source dropdowns populate offline.
+    // `inputId = slot * 4 + conn` gives a unique identifier across all cards;
+    // formatSourceVariable builds `source_${inputId}_${cropId}` variable ids,
+    // so duplicate inputIds would collide and only the last entry would show.
     this.sourceList = [];
     for (let slot = 0; slot < inputCardCount; slot++) {
       for (let conn = 0; conn < 4; conn++) {
+        const inputId = slot * 4 + conn;
         this.sourceList.push({
-          id: `offline_input_${slot + 1}_${conn + 1}`,
+          inputId,
+          cropId: 255,
+          streamId: 0,
+          templateId: 0,
+          sourceType: 1,
           groupName: 'Video Inputs',
           name: `Input ${slot + 1}-${conn + 1}`,
           inputName: `Input ${slot + 1}-${conn + 1}`,
           slotId: slot,
           interfaceId: conn,
-          templateId: 0,
-          cropId: 255,
+          online: 1,
         });
       }
     }

--- a/src/main.js
+++ b/src/main.js
@@ -202,8 +202,76 @@ class ModuleInstance extends InstanceBase {
       ...config,
     };
 
+    // Offline Programming Mode: synthesize a virtual screen/layer/preset tree
+    // so variables, actions, and feedbacks all work without a device. Useful
+    // when building buttons for a show before rental/deployment hardware
+    // is on-site.
+    if (this.config.offlineMode) {
+      this.generateOfflineData();
+      this.updateAll();
+      this.log('info', 'Offline Programming Mode enabled');
+      this.updateStatus(InstanceStatus.Ok, 'Offline Programming Mode');
+      return;
+    }
+
     this.updateStatus(InstanceStatus.Connecting);
     this.initUDP();
+  }
+
+  /**
+   * Generate synthetic screenList/presetCollectionList/sourceList data from
+   * the configured screen and input card counts so offline programming can
+   * populate variable dropdowns and previews.
+   */
+  generateOfflineData() {
+    const screenCount = this.config.screenCount || 4;
+    const inputCardCount = this.config.inputCardCount || 1;
+    const PRESETS_PER_SCREEN = 20;
+
+    this.screenList = [];
+    for (let i = 0; i < screenCount; i++) {
+      this.screenList.push({
+        screenId: i,
+        name: `Screen ${i + 1}`,
+        layers: [
+          { layerId: 0, name: 'Layer 1' },
+          { layerId: 1, name: 'Layer 2' },
+          { layerId: 2, name: 'Layer 3' },
+          { layerId: 3, name: 'Layer 4' },
+        ],
+        presets: Array.from({ length: PRESETS_PER_SCREEN }, (_, p) => ({
+          presetId: p,
+          name: `Preset ${p + 1}`,
+        })),
+        details: {
+          screenId: i,
+          brightness: 100,
+          screenFrz: 0,
+          blackout: 1, // 1 = not blacked out (protocol inverted: 0=FTB on)
+          bkgEnable: 0,
+          textOsdEnable: 0,
+          imgOsdEnable: 0,
+        },
+      });
+    }
+
+    this.presetCollectionList = [];
+    // Synthetic input source entries so source dropdowns populate offline
+    this.sourceList = [];
+    for (let slot = 0; slot < inputCardCount; slot++) {
+      for (let conn = 0; conn < 4; conn++) {
+        this.sourceList.push({
+          id: `offline_input_${slot + 1}_${conn + 1}`,
+          groupName: 'Video Inputs',
+          name: `Input ${slot + 1}-${conn + 1}`,
+          inputName: `Input ${slot + 1}-${conn + 1}`,
+          slotId: slot,
+          interfaceId: conn,
+          templateId: 0,
+          cropId: 255,
+        });
+      }
+    }
   }
 
   /** 更新actions、presets、feedbacks */
@@ -248,6 +316,11 @@ class ModuleInstance extends InstanceBase {
   }
 
   getConfigFields() {
+    const screenCountChoices = [];
+    for (let i = 1; i <= 40; i++) screenCountChoices.push({ id: i, label: `${i}` });
+    const inputCardChoices = [];
+    for (let i = 1; i <= 40; i++) inputCardChoices.push({ id: i, label: `${i} (${i * 4} inputs)` });
+
     return [
       {
         type: 'static-text',
@@ -271,6 +344,39 @@ class ModuleInstance extends InstanceBase {
         width: 6,
         default: '6000',
         regex: Regex.PORT,
+      },
+      {
+        type: 'static-text',
+        id: 'offline_heading',
+        width: 12,
+        label: 'Offline Programming',
+        value:
+          'Enable Offline Programming Mode to build and test buttons against a synthetic device — useful when hardware arrives after the show is being programmed. Actions will be silently no-op for the UDP layer; variables and feedbacks populate from the counts below.',
+      },
+      {
+        type: 'checkbox',
+        id: 'offlineMode',
+        label: 'Enable Offline Programming Mode',
+        width: 6,
+        default: false,
+      },
+      {
+        type: 'dropdown',
+        id: 'screenCount',
+        label: 'Number of Screens',
+        width: 6,
+        default: 1,
+        choices: screenCountChoices,
+        tooltip: 'Used in offline mode to synthesize the screen list. Overridden by live device data when connected.',
+      },
+      {
+        type: 'dropdown',
+        id: 'inputCardCount',
+        label: 'Number of Input Cards',
+        width: 6,
+        default: 1,
+        choices: inputCardChoices,
+        tooltip: 'Used in offline mode to synthesize input source entries (each card has 4 connectors).',
       },
     ];
   }
@@ -389,11 +495,10 @@ class ModuleInstance extends InstanceBase {
   /** devices cmd handle end */
 
   async configUpdated(config) {
-    let resetConnection = false;
-
-    if (this.config.host != config.host) {
-      resetConnection = true;
-    }
+    const hostChanged = this.config.host != config.host;
+    const offlineModeChanged = this.config.offlineMode !== config.offlineMode;
+    const sizeChanged =
+      this.config.screenCount !== config.screenCount || this.config.inputCardCount !== config.inputCardCount;
 
     this.log('info', 'configUpdated module....');
 
@@ -402,16 +507,45 @@ class ModuleInstance extends InstanceBase {
       ...config,
     };
 
-    if (resetConnection) {
-      this.updateStatus(InstanceStatus.Connecting);
+    // If offline mode is on and size changed, regenerate synthetic data
+    if (sizeChanged && this.config.offlineMode) {
+      this.generateOfflineData();
+      this.updateAll();
+    }
 
-      // 停止心跳和初始化状态定时器，防止旧连接残留
+    // Handle offline mode toggle
+    if (offlineModeChanged) {
+      if (this.config.offlineMode) {
+        // Entering offline mode — tear down any live connection cleanly
+        if (this.udp) {
+          this.udp.destroy();
+          delete this.udp;
+        }
+        if (this.dataInterval) {
+          clearInterval(this.dataInterval);
+          this.dataInterval = null;
+        }
+        this.heartbeatManager.stop();
+        this.clearInitStatusTimer();
+        this.connectStatus = false;
+        this.generateOfflineData();
+        this.updateAll();
+        this.updateStatus(InstanceStatus.Ok, 'Offline Programming Mode');
+        return;
+      } else {
+        // Leaving offline mode — clear synthetic data, let host path take over
+        this.screenList = [];
+        this.presetCollectionList = [];
+        this.sourceList = [];
+        this.updateAll();
+      }
+    }
+
+    if (hostChanged && !this.config.offlineMode) {
+      this.updateStatus(InstanceStatus.Connecting);
       this.heartbeatManager.stop();
       this.clearInitStatusTimer();
-
-      // 重新初始化UDP
       this.initUDP();
-
       this.handleGetAllData();
     }
   }

--- a/src/main.js
+++ b/src/main.js
@@ -540,11 +540,24 @@ class ModuleInstance extends InstanceBase {
         this.updateStatus(InstanceStatus.Ok, 'Offline Programming Mode');
         return;
       } else {
-        // Leaving offline mode — clear synthetic data, let host path take over
+        // Leaving offline mode — clear synthetic data and immediately fetch
+        // real device state so Presets/Feedback refresh without needing a
+        // host change or polling cycle.
         this.screenList = [];
         this.presetCollectionList = [];
         this.sourceList = [];
+        this.connectStatus = false;
         this.updateAll();
+        if (this.config.host) {
+          this.updateStatus(InstanceStatus.Connecting);
+          this.heartbeatManager.stop();
+          this.clearInitStatusTimer();
+          this.initUDP();
+          this.handleGetAllData();
+        } else {
+          this.updateStatus(InstanceStatus.Disconnected, 'No host configured');
+        }
+        return;
       }
     }
 


### PR DESCRIPTION
## Summary

New config toggle that lets operators program Companion against a
synthetic device when the real splicer isn't on the network yet. Split
out from #35 per @NovaStar-Service's request.

### Why

Live-event workflow: rental gear arrives Tuesday, the show goes up Wednesday, but button programming has to happen the week before. With upstream, Companion won't populate screen/layer/preset/source variables until the module is talking to a real splicer — so ops can't build their layouts ahead of time.

Offline Programming Mode lets them configure "4 screens, 2 input cards" and get a fully-populated variable namespace + working action/feedback dropdowns without a host.

## What's new

- **`offlineMode` checkbox** (default off).
- **`screenCount` dropdown** (1–40) and **`inputCardCount` dropdown** (1–40, 4 connectors each) — only used when offline; live device data overrides them on connect.
- **`generateOfflineData()`** synthesizes `screenList` (with layers + 20 presets each), an empty `presetCollectionList`, and a `sourceList` covering all slot×connector pairs.
- **`init()`** short-circuits when offlineMode is on: generates data, publishes actions/feedbacks/variables, sets status to `Ok / Offline Programming Mode`, and does NOT open a UDP socket.
- **`configUpdated()`** handles all four transitions cleanly:
  - size change while offline → regenerate synthetic data
  - toggle offline → on: tear down any live connection, generate data, status OK
  - toggle offline → off: clear synthetic data, fall through to live host path
  - host change (non-offline) → reconnect as before

## Regression scope

When `offlineMode` is off (default), the module runs the exact upstream paths. The only touched existing code is `configUpdated`, where the `hostChanged` reconnect is now guarded on `!offlineMode` (unchanged behavior outside offline mode).

## Test plan

- [x] Offline mode on with no host → status `Ok / Offline Programming Mode`, variables populate, action dropdowns show synthetic screens/presets/inputs
- [x] Toggle offline → on while connected: clean teardown of heartbeat/UDP; no stale actions
- [x] Toggle offline → off: synthetic data clears, live host path takes over
- [x] Change `screenCount` / `inputCardCount` while offline → variables update