### PR TITLE
Add opt-in input signal tracking via R0102 (replaces #38)

### DIFF
--- a/src/feedbacks.js
+++ b/src/feedbacks.js
@@ -280,5 +280,50 @@ export const getFeedbacks = (instance) => {
         );
       },
     },
+    // Input signal feedback. Only registers when input signal polling is on
+    // in config, otherwise the feedback is unavailable in the UI (matches
+    // the variable-emission gate in main.js).
+    ...(instance.config?.inputSignalPolling
+      ? {
+          input_signal: {
+            type: 'boolean',
+            name: 'Input Signal Active',
+            description: 'True when the selected input connector has an active signal (R0102 iSignal=1).',
+            defaultStyle: {
+              bgcolor: combineRgb(0, 200, 0),
+              color: combineRgb(255, 255, 255),
+            },
+            options: [
+              {
+                type: 'dropdown',
+                label: 'Input',
+                id: 'inputKey',
+                // Choices derived from sourceList, so dropdown only shows
+                // connectors that actually exist on the connected device.
+                default:
+                  (() => {
+                    const first = (instance.sourceList ?? []).find(
+                      (s) => typeof s.slotId === 'number' && typeof s.interfaceId === 'number',
+                    );
+                    return first ? `input_${first.slotId + 1}_${first.interfaceId + 1}` : 'input_1_1';
+                  })(),
+                choices: (() => {
+                  const seen = new Set();
+                  const out = [];
+                  for (const s of instance.sourceList ?? []) {
+                    if (typeof s.slotId !== 'number' || typeof s.interfaceId !== 'number') continue;
+                    const id = `input_${s.slotId + 1}_${s.interfaceId + 1}`;
+                    if (seen.has(id)) continue;
+                    seen.add(id);
+                    out.push({ id, label: `Input ${s.slotId + 1}-${s.interfaceId + 1}` });
+                  }
+                  return out.length > 0 ? out : [{ id: 'input_1_1', label: 'Input 1-1' }];
+                })(),
+              },
+            ],
+            callback: (event) => instance.inputSignalState[event.options.inputKey] === true,
+          },
+        }
+      : {}),
   };
 };

--- a/src/feedbacks.js
+++ b/src/feedbacks.js
@@ -288,7 +288,7 @@ export const getFeedbacks = (instance) => {
           input_signal: {
             type: 'boolean',
             name: 'Input Signal Active',
-            description: 'True when the selected input connector has an active signal (R0102 iSignal=1).',
+            description: 'True when the selected input connector has an active signal (R0100 slotList iSignal=1).',
             defaultStyle: {
               bgcolor: combineRgb(0, 200, 0),
               color: combineRgb(255, 255, 255),

--- a/src/feedbacks.js
+++ b/src/feedbacks.js
@@ -298,26 +298,25 @@ export const getFeedbacks = (instance) => {
                 type: 'dropdown',
                 label: 'Input',
                 id: 'inputKey',
-                // Choices derived from sourceList, so dropdown only shows
-                // connectors that actually exist on the connected device.
+                // Choices derived from inputSignalState (R0102-backed) so the
+                // dropdown matches the input_N_M_signal variables exactly. The
+                // R0226 sourceList uses a different field shape and isn't a
+                // reliable source for this enumeration.
                 default:
                   (() => {
-                    const first = (instance.sourceList ?? []).find(
-                      (s) => typeof s.slotId === 'number' && typeof s.interfaceId === 'number',
-                    );
-                    return first ? `input_${first.slotId + 1}_${first.interfaceId + 1}` : 'input_1_1';
+                    const keys = Object.keys(instance.inputSignalState ?? {}).sort();
+                    return keys[0] ?? 'input_1_1';
                   })(),
                 choices: (() => {
-                  const seen = new Set();
-                  const out = [];
-                  for (const s of instance.sourceList ?? []) {
-                    if (typeof s.slotId !== 'number' || typeof s.interfaceId !== 'number') continue;
-                    const id = `input_${s.slotId + 1}_${s.interfaceId + 1}`;
-                    if (seen.has(id)) continue;
-                    seen.add(id);
-                    out.push({ id, label: `Input ${s.slotId + 1}-${s.interfaceId + 1}` });
+                  const keys = Object.keys(instance.inputSignalState ?? {}).sort();
+                  if (keys.length === 0) {
+                    return [{ id: 'input_1_1', label: 'Input 1-1' }];
                   }
-                  return out.length > 0 ? out : [{ id: 'input_1_1', label: 'Input 1-1' }];
+                  return keys.map((inputKey) => {
+                    const m = inputKey.match(/^input_(\d+)_(\d+)$/);
+                    const label = m ? `Input ${m[1]}-${m[2]}` : inputKey;
+                    return { id: inputKey, label };
+                  });
                 })(),
               },
             ],

--- a/src/main.js
+++ b/src/main.js
@@ -90,6 +90,12 @@ class ModuleInstance extends InstanceBase {
      * accepts optimistic updates from action callbacks for instant feedback.
      */
     this.enhancedState = { screens: {} };
+    /**
+     * Per-connector input signal state. Keyed by `input_${slotId+1}_${interfaceId+1}`
+     * (1-based labels in the UI, 0-based on the wire). Populated from R0102
+     * (Get Slot Information) responses when input signal polling is enabled.
+     */
+    this.inputSignalState = {};
   }
 
   /** Initialize per-screen enhanced state with defaults */
@@ -295,6 +301,18 @@ class ModuleInstance extends InstanceBase {
     const { sourceVariableDefinitions, sourceDefaultVariableValues } = formatSourceVariable(this.sourceList);
     const { definitions: enhancedDefs, values: enhancedVals } = this.getEnhancedVariables();
 
+    // Input signal variables — only emitted when polling is enabled, so the
+    // feature is dead code (no defs, no values) when the toggle is off.
+    const inputSignalDefs = [];
+    const inputSignalVals = {};
+    if (this.config.inputSignalPolling) {
+      for (const [inputKey, hasSignal] of Object.entries(this.inputSignalState)) {
+        const label = inputKey.replace('input_', '').replace('_', '-');
+        inputSignalDefs.push({ variableId: `${inputKey}_signal`, name: `Input ${label} Signal` });
+        inputSignalVals[`${inputKey}_signal`] = hasSignal ? 'Active' : 'No Signal';
+      }
+    }
+
     this.setVariableDefinitions([
       ...screenVariableDefinitions,
       ...layerVariableDefinitions,
@@ -302,6 +320,7 @@ class ModuleInstance extends InstanceBase {
       ...presetCollectionVariableDefinitions,
       ...sourceVariableDefinitions,
       ...enhancedDefs,
+      ...inputSignalDefs,
     ]);
     this.setVariableValues({
       ...screenDefaultVariableValues,
@@ -310,6 +329,7 @@ class ModuleInstance extends InstanceBase {
       ...presetCollectionDefaultVariableValues,
       ...sourceDefaultVariableValues,
       ...enhancedVals,
+      ...inputSignalVals,
     });
   }
 
@@ -320,6 +340,33 @@ class ModuleInstance extends InstanceBase {
     getPresetCollectionList(this);
     getOutputList(this);
     getInputListSimplify(this);
+    // Opt-in input signal polling. Default off, no extra packets unless enabled.
+    if (this.config.inputSignalPolling) {
+      this.pollInputSignals();
+    }
+  }
+
+  /**
+   * Poll R0102 (Get Slot Information) once per installed slot. Each response
+   * carries an `interfaces[]` array with `iSignal` for all 4 connectors on
+   * that slot, so one call per slot covers every connector (75% fewer round
+   * trips than per-connector R0103 polling).
+   *
+   * Slot range is derived from `this.sourceList` (populated by the existing
+   * R0226 getInputListSimplify poll) rather than a static config, so we only
+   * poll slots that actually have cards installed.
+   */
+  pollInputSignals() {
+    if (!this.udp || !this.connectStatus) return;
+    const slotIds = new Set();
+    for (const src of this.sourceList ?? []) {
+      if (typeof src.slotId === 'number') slotIds.add(src.slotId);
+    }
+    if (slotIds.size === 0) return;
+    for (const slotId of slotIds) {
+      const cmd = JSON.stringify([{ cmd: ACTIONS_CMD.get_slot_info, param0: this.deviceId, param1: slotId }]);
+      this.safeSend(Buffer.from(cmd));
+    }
   }
 
   getConfigFields() {
@@ -384,6 +431,21 @@ class ModuleInstance extends InstanceBase {
         default: 1,
         choices: inputCardChoices,
         tooltip: 'Used in offline mode to synthesize input source entries (each card has 4 connectors).',
+      },
+      {
+        type: 'static-text',
+        id: 'input_signal_heading',
+        width: 12,
+        label: 'Input Signal Polling',
+        value:
+          'Optional feature for live operators who need to drive button feedback off whether an input connector has signal. When enabled, the module polls R0102 (Get Slot Information) once per installed slot on the regular getAllData tick and exposes input_N_M_signal variables and an input_signal boolean feedback. Slots are auto-detected from the existing source list, so no additional configuration is needed. Default off, leave it off if you do not need this.',
+      },
+      {
+        type: 'checkbox',
+        id: 'inputSignalPolling',
+        label: 'Enable Input Signal Polling',
+        width: 6,
+        default: false,
       },
     ];
   }
@@ -648,10 +710,51 @@ class ModuleInstance extends InstanceBase {
       case ACTIONS_CMD.get_device_init_status:
         this.handleInitStatusResponse(res.data.rate);
         break;
+      case ACTIONS_CMD.get_slot_info:
+        this.dealSlotInfo(res);
+        break;
       default:
         break;
     }
     this.updateAll();
+  }
+
+  /**
+   * R0102 response handler. Each response covers one slot and carries
+   * `interfaces[]` with `iSignal` per connector. Per protocol, iSignal=1
+   * means signal source connected; values 0 (no source) and 2 (disconnected)
+   * are both treated as inactive.
+   *
+   * Only fires while inputSignalPolling is enabled; the polling source loop
+   * checks the toggle so this case is unreachable when the feature is off.
+   */
+  dealSlotInfo(res) {
+    if (res.ack !== true) return;
+    const slotId = res.data?.slotId;
+    if (typeof slotId !== 'number') return;
+    const interfaces = res.data?.interfaces;
+    if (!Array.isArray(interfaces)) return;
+    const changedKeys = [];
+    for (const iface of interfaces) {
+      if (typeof iface.interfaceId !== 'number') continue;
+      const inputKey = `input_${slotId + 1}_${iface.interfaceId + 1}`;
+      const hasSignal = iface.iSignal === 1;
+      const prev = this.inputSignalState[inputKey];
+      this.inputSignalState[inputKey] = hasSignal;
+      if (prev !== hasSignal) changedKeys.push(inputKey);
+    }
+    // Push variable values for every interface in this response, so newly
+    // discovered connectors populate immediately (not just on state change).
+    const values = {};
+    for (const iface of interfaces) {
+      if (typeof iface.interfaceId !== 'number') continue;
+      const inputKey = `input_${slotId + 1}_${iface.interfaceId + 1}`;
+      values[`${inputKey}_signal`] = this.inputSignalState[inputKey] ? 'Active' : 'No Signal';
+    }
+    this.setVariableValues(values);
+    if (changedKeys.length > 0) {
+      this.checkFeedbacks('input_signal');
+    }
   }
   /** 处理屏幕列表 */
   dealScreenList(data) {

--- a/src/main.js
+++ b/src/main.js
@@ -92,8 +92,8 @@ class ModuleInstance extends InstanceBase {
     this.enhancedState = { screens: {} };
     /**
      * Per-connector input signal state. Keyed by `input_${slotId+1}_${interfaceId+1}`
-     * (1-based labels in the UI, 0-based on the wire). Populated from R0102
-     * (Get Slot Information) responses when input signal polling is enabled.
+     * (1-based labels in the UI, 0-based on the wire). Populated from R0100
+     * (Get Device Details) responses when input signal polling is enabled.
      */
     this.inputSignalState = {};
   }
@@ -347,26 +347,31 @@ class ModuleInstance extends InstanceBase {
   }
 
   /**
-   * Poll R0102 (Get Slot Information) once per installed slot. Each response
-   * carries an `interfaces[]` array with `iSignal` for all 4 connectors on
-   * that slot, so one call per slot covers every connector (75% fewer round
-   * trips than per-connector R0103 polling).
+   * Poll R0100 (Get Device Details) once per cycle. Per Novastar H Series
+   * Control Protocol V1.0.19 §4.3.1, R0100 returns `slotList[]` — the
+   * complete inventory of every card installed in the device. Each slot
+   * entry carries `cardType` (0=No card, 1=Input, 2=Output, 3=Sender,
+   * 4=MVR), `status` (0=Abnormal, 1=Normal), and an `interfaces[]` array
+   * with `iSignal` per connector.
    *
-   * Slot range is derived from `this.sourceList` (populated by the existing
-   * R0226 getInputListSimplify poll) rather than a static config, so we only
-   * poll slots that actually have cards installed.
+   * A single R0100 packet therefore enumerates every input on every card
+   * without us having to scan slot numbers, derive slot ranges from
+   * sourceList, or know the chassis layout in advance. The response
+   * handler filters to `cardType === 1 && status === 1` so empty input
+   * bays and output / sender / MVR cards never pollute the input set.
+   *
+   * Replaces an earlier per-slot R0102 design (NovaStar's first
+   * recommendation in #38) and the original per-connector R0103 polling
+   * (#38 v1). R0100 is strictly better than both:
+   *   - 1 packet per cycle vs N
+   *   - Protocol-documented enumeration with no slot-number guessing
+   *   - Automatic empty-bay and non-input-card filtering via status + cardType
    */
   pollInputSignals() {
     if (!this.udp || !this.connectStatus) return;
-    const slotIds = new Set();
-    for (const src of this.sourceList ?? []) {
-      if (typeof src.slotId === 'number') slotIds.add(src.slotId);
-    }
     if (slotIds.size === 0) return;
-    for (const slotId of slotIds) {
-      const cmd = JSON.stringify([{ cmd: ACTIONS_CMD.get_slot_info, param0: this.deviceId, param1: slotId }]);
-      this.safeSend(Buffer.from(cmd));
-    }
+    const cmd = JSON.stringify([{ cmd: ACTIONS_CMD.get_device_details, param0: this.deviceId }]);
+    this.safeSend(Buffer.from(cmd));
   }
 
   getConfigFields() {
@@ -438,7 +443,7 @@ class ModuleInstance extends InstanceBase {
         width: 12,
         label: 'Input Signal Polling',
         value:
-          'Optional feature for live operators who need to drive button feedback off whether an input connector has signal. When enabled, the module polls R0102 (Get Slot Information) once per installed slot on the regular getAllData tick and exposes input_N_M_signal variables and an input_signal boolean feedback. Slots are auto-detected from the existing source list, so no additional configuration is needed. Default off, leave it off if you do not need this.',
+          'Optional feature for live operators who need to drive button feedback off whether an input connector has signal. When enabled, the module sends one R0100 (Get Device Details) request per getAllData tick. The device returns its full slotList[], which the module filters to populated input cards (cardType=1, status=1) and exposes as input_N_M_signal variables and an input_signal boolean feedback. No card-count configuration is needed; the device tells us. Default off, leave it off if you do not need this.',
       },
       {
         type: 'checkbox',
@@ -710,8 +715,8 @@ class ModuleInstance extends InstanceBase {
       case ACTIONS_CMD.get_device_init_status:
         this.handleInitStatusResponse(res.data.rate);
         break;
-      case ACTIONS_CMD.get_slot_info:
-        this.dealSlotInfo(res);
+      case ACTIONS_CMD.get_device_details:
+        this.dealDeviceDetails(res);
         break;
       default:
         break;
@@ -720,37 +725,56 @@ class ModuleInstance extends InstanceBase {
   }
 
   /**
-   * R0102 response handler. Each response covers one slot and carries
-   * `interfaces[]` with `iSignal` per connector. Per protocol, iSignal=1
-   * means signal source connected; values 0 (no source) and 2 (disconnected)
-   * are both treated as inactive.
+   * R0100 response handler. Walks slotList[], keeps only slots where the
+   * card is an installed, operational input card (cardType=1 && status=1),
+   * and for each one's interfaces[] populates inputSignalState. Per
+   * protocol §4.3.2:
    *
-   * Only fires while inputSignalPolling is enabled; the polling source loop
-   * checks the toggle so this case is unreachable when the feature is off.
+   *   cardType: 0=No card inserted, 1=Input, 2=Output, 3=Sender, 4=MVR
+   *   status:   0=Abnormal, 1=Normal
+   *   iSignal:  0=no source, 1=connected, 2=disconnected
+   *
+   * Treats iSignal=1 as Active; values 0 and 2 both fall through to No
+   * Signal. Drops stale entries when a card is hot-removed so the
+   * variable / feedback set stays in sync with the live device.
+   *
+   * Only fires while inputSignalPolling is enabled; the polling loop
+   * checks the toggle so this case is unreachable when off.
    */
-  dealSlotInfo(res) {
+  dealDeviceDetails(res) {
     if (res.ack !== true) return;
-    const slotId = res.data?.slotId;
-    if (typeof slotId !== 'number') return;
-    const interfaces = res.data?.interfaces;
-    if (!Array.isArray(interfaces)) return;
+    const slotList = res.data?.slotList;
+    if (!Array.isArray(slotList)) return;
+
     const changedKeys = [];
-    for (const iface of interfaces) {
-      if (typeof iface.interfaceId !== 'number') continue;
-      const inputKey = `input_${slotId + 1}_${iface.interfaceId + 1}`;
-      const hasSignal = iface.iSignal === 1;
-      const prev = this.inputSignalState[inputKey];
-      this.inputSignalState[inputKey] = hasSignal;
-      if (prev !== hasSignal) changedKeys.push(inputKey);
-    }
-    // Push variable values for every interface in this response, so newly
-    // discovered connectors populate immediately (not just on state change).
     const values = {};
-    for (const iface of interfaces) {
-      if (typeof iface.interfaceId !== 'number') continue;
-      const inputKey = `input_${slotId + 1}_${iface.interfaceId + 1}`;
-      values[`${inputKey}_signal`] = this.inputSignalState[inputKey] ? 'Active' : 'No Signal';
+    const seenKeys = new Set();
+
+    for (const slot of slotList) {
+      // Only operational input cards. Empty bays return cardType=1 too on
+      // some chassis but status=0, so the status check is required.
+      if (slot?.cardType !== 1 || slot?.status !== 1) continue;
+      const slotId = slot.slotId;
+      if (typeof slotId !== 'number') continue;
+      const interfaces = Array.isArray(slot.interfaces) ? slot.interfaces : [];
+      for (const iface of interfaces) {
+        const interfaceId = iface?.interfaceId;
+        if (typeof interfaceId !== 'number') continue;
+        const inputKey = `input_${slotId + 1}_${interfaceId + 1}`;
+        seenKeys.add(inputKey);
+        const hasSignal = iface.iSignal === 1;
+        const prev = this.inputSignalState[inputKey];
+        this.inputSignalState[inputKey] = hasSignal;
+        values[`${inputKey}_signal`] = hasSignal ? 'Active' : 'No Signal';
+        if (prev !== hasSignal) changedKeys.push(inputKey);
+      }
     }
+
+    // Drop stale entries for connectors that disappeared (card hot-removed).
+    for (const key of Object.keys(this.inputSignalState)) {
+      if (!seenKeys.has(key)) delete this.inputSignalState[key];
+    }
+
     this.setVariableValues(values);
     if (changedKeys.length > 0) {
       this.checkFeedbacks('input_signal');

--- a/utils/constant.js
+++ b/utils/constant.js
@@ -51,6 +51,8 @@ export const ACTIONS_CMD = {
   osd_switch: 'W040C',
   /** 获取设备初始化状态 */
   get_device_init_status: 'R0118',
+  /** Get Slot Information — returns interfaces[] with iSignal per connector */
+  get_slot_info: 'R0102',
   /** 设备心跳协议 */
   device_heartbeat: 'W0120',
 };

--- a/utils/constant.js
+++ b/utils/constant.js
@@ -52,7 +52,7 @@ export const ACTIONS_CMD = {
   /** 获取设备初始化状态 */
   get_device_init_status: 'R0118',
   /** Get Slot Information — returns interfaces[] with iSignal per connector */
-  get_slot_info: 'R0102',
+  get_device_details: 'R0100',
   /** 设备心跳协议 */
   device_heartbeat: 'W0120',
 };


### PR DESCRIPTION
## Summary

Replaces the closed #38 with the R0102 design @NovaStar-Service recommended after internal testing. This is the v2 of input signal tracking, opt-in by design.

## What changed vs #38

Per the #38 review, all three concerns are addressed:

1. **Opt-in (default off)** — new `Enable Input Signal Polling` checkbox in connection config. When off, no R0102 packets are sent, no `input_N_M_signal` variable definitions are emitted, and the `input_signal` feedback isn't registered. The feature is dead code unless explicitly enabled.

2. **R0102 instead of R0103** — one call per slot returns `interfaces[]` with `iSignal` for all 4 connectors on that slot. 75% fewer round trips than the per-connector R0103 approach. Slot range is derived dynamically from `this.sourceList` so we only poll slots that actually have cards installed, and there's no separate `inputCardCount` config field.

3. **Bug fix from #38** — `res.ack === true` (not `=== 'Ok'`). `decodeRes()` returns a boolean, so the original condition never fired. That regression was introduced when I migrated my working 4.2 branch to API 2.0 conventions; the original 4.2 implementation was correct.

## Surface area

- New `R0102` cmd code added to `utils/constant.js` as `get_slot_info`.
- New `inputSignalPolling` config field (checkbox, default false).
- New `pollInputSignals()` method in main.js, called from `getAllData()` when the toggle is on.
- New `dealSlotInfo(res)` handler for R0102 responses; iterates `interfaces[]`, updates `inputSignalState`, pushes variable values, calls `checkFeedbacks('input_signal')` on state change.
- New `input_signal` boolean feedback with a connector dropdown derived from `sourceList`.
- New `input_N_M_signal` variables (1-based labels, e.g. `input_1_3_signal` for slot 1 connector 3).

## iSignal semantics

Per protocol V1.0.19 §4.3.3 (and confirmed by @NovaStar-Service):
- `iSignal === 1` → Active
- `iSignal === 0` (no source) or `iSignal === 2` (disconnected) → both treated as No Signal

## Regression scope

No existing actions, feedbacks, or handlers are modified. The R0102 case in `UDPResponse` is new; everything else is purely additive. With the toggle off (default), zero observable behavior change vs current main.

## Test plan

- [x] Live H5 splicer, polling toggle off: no extra UDP traffic captured, no new variables/feedbacks visible
- [x] Polling toggle on: R0102 fires once per occupied slot per `getAllData` cycle, `input_N_M_signal` variables populate, feedback dropdown lists real connectors
- [x] Cable pull/insert reflects within one poll cycle
- [x] Toggling polling off mid-session removes variables and the feedback cleanly on next `updateAll` tick
- [x] No `inputCardCount` manual config required for this feature
