### PR TITLE
Add save_brightness and global blackout actions (missed during PR split)

### DIFF
--- a/src/actions.js
+++ b/src/actions.js
@@ -843,5 +843,50 @@ export const getActions = (instance) => {
         sendUDPRequestsSync(instance, requests);
       },
     },
+    // Save current screen brightness to the LED receiving card hardware (W0417)
+    // so the brightness setting persists across a power cycle.
+    save_brightness: {
+      name: 'Save Brightness',
+      description: 'Save the current screen brightness to the LED receiving card hardware so it survives a reboot.',
+      options: [
+        {
+          type: 'dropdown',
+          name: 'Screen',
+          label: 'Screen',
+          id: 'screenId',
+          default: screenListDropDown[0]?.id ?? null,
+          choices: screenListDropDown,
+        },
+      ],
+      callback: (event) => {
+        const screenId = event.options.screenId;
+        const command = handleParams(ACTIONS_CMD.save_screen_brightness, { screenId });
+        instance.safeSend(command);
+      },
+    },
+    // Global blackout (W0700). Distinct from per-screen FTB / black_screen —
+    // this affects every screen on the device at once.
+    blackout: {
+      name: 'Blackout (Global)',
+      description: 'Enable or disable a global blackout across every screen on the device. Distinct from per-screen FTB.',
+      options: [
+        {
+          type: 'dropdown',
+          name: 'State',
+          label: 'State',
+          id: 'state',
+          default: 1,
+          choices: [
+            { id: 1, label: 'Enable' },
+            { id: 0, label: 'Disable' },
+          ],
+        },
+      ],
+      callback: (event) => {
+        const state = parseInt(event.options.state);
+        const command = handleParams(ACTIONS_CMD.blackout, { blackout: state });
+        instance.safeSend(command);
+      },
+    },
   };
 };

--- a/utils/constant.js
+++ b/utils/constant.js
@@ -53,6 +53,10 @@ export const ACTIONS_CMD = {
   get_device_init_status: 'R0118',
   /** 设备心跳协议 */
   device_heartbeat: 'W0120',
+  /** Save current screen brightness to LED receiving card (per screen) */
+  save_screen_brightness: 'W0417',
+  /** Global blackout — affects all screens at once */
+  blackout: 'W0700',
 };
 
 export const SCREEN_COUNT_H = 40;


### PR DESCRIPTION
## Summary

Two actions that existed on my pre-split working branch but didn't make it into the four-way split (#37 / #39 / #40). Catching them up here as a small focused PR.

## Background — how these got missed

When I split the original mega-PR (#35) into four feature-scoped branches, I rebuilt each branch by hand against upstream/main rather than cherry-picking. In the rebuild I scoped each branch to its named feature (safe-send, direct-actions, offline-mode, input-signal) and these two unrelated actions fell off the list. Found them when @kman1898 audited the merged result against the pre-split source. My fault, easy to fix.

## What's added

### `save_brightness` action (W0417)
Per-screen action that persists the current brightness setting to the LED receiving card hardware. Operators routinely tweak brightness throughout a day to match ambient light changes; without this action, those tweaks are lost on the next power cycle. Companion to the existing `screen_brightness_add` / `screen_brightness_minus` / `set_brightness` actions.

### `blackout` action (W0700)
Global blackout across every screen on the device, in a single command. Distinct from the existing per-screen `black_screen` / FTB:

| | Cmd | Scope |
|---|---|---|
| `black_screen` (existing) | W0409 | Per-screen FTB, requires screen selection |
| `blackout` (new) | W0700 | Global, all screens at once |

Useful for emergency "kill everything" buttons, and for shows where the operator wants a single-press all-screens cut instead of selecting every screen first.

## Surface

- 2 actions added in `src/actions.js`
- 2 cmd codes added in `utils/constant.js` (`save_screen_brightness: 'W0417'`, `blackout: 'W0700'`)

## Regression scope

Strictly additive. No existing actions, feedbacks, handlers, or constants are modified.

## Test plan

- [x] `save_brightness` against live H5: cycle power, brightness setting persists
- [x] `blackout` against live H5: all four screens cut to black on press, restore on disable
- [x] Existing per-screen `black_screen` / FTB actions continue to work
