### PR TITLE
Add per-screen direct presets (followup to #39)

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
 	"dependencies": {
 		"@companion-module/base": "~1.5.1",
 		"axios": "^1.15.2",
+		"companion-module-utils": "^0.4.0",
 		"got": "^13.0.0",
 		"ping": "^0.4.4",
 		"yarn": "^1.22.21"

--- a/src/feedbacks.js
+++ b/src/feedbacks.js
@@ -1,4 +1,5 @@
 import { combineRgb } from '@companion-module/base';
+import { graphics } from 'companion-module-utils';
 import { PGM_PVW_TYPE } from '../utils/constant.js';
 import formatDropDownData from '../utils/formatDropDown.js';
 
@@ -194,6 +195,39 @@ export const getFeedbacks = (instance) => {
       callback: (event) => {
         const s = instance.enhancedState?.screens[event.options.screenId];
         return s ? s.brightness === event.options.value : false;
+      },
+    },
+    // Graphical brightness bar (Resolume-style progress bar). Draws a
+    // horizontal bar across the bottom of the button reflecting the chosen
+    // screen's 0-100 brightness. Pair with a button whose text shows the
+    // screen name + the screen_N_brightness variable for a clean readout.
+    brightness_bar: {
+      type: 'advanced',
+      name: 'Brightness Bar (Direct)',
+      description: 'Horizontal progress bar showing a screen brightness (0-100). Pair with the brightness variable in the button text.',
+      options: [
+        { type: 'dropdown', label: 'Screen', id: 'screenId', default: screenListDropDown[0]?.id ?? null, choices: screenListDropDown },
+        { type: 'colorpicker', label: 'Bar color', id: 'barColor', default: combineRgb(0, 200, 0), returnType: 'number' },
+      ],
+      callback: (feedback) => {
+        const s = instance.enhancedState?.screens[feedback.options.screenId];
+        const value = s && typeof s.brightness === 'number' ? Math.max(0, Math.min(100, s.brightness)) : 0;
+        const barColor = Number(feedback.options.barColor);
+        const width = feedback.image?.width ?? 72;
+        const height = feedback.image?.height ?? 72;
+        const options = {
+          width,
+          height,
+          colors: [{ size: 100, color: barColor, background: barColor, backgroundOpacity: 64 }],
+          barLength: width - 10,
+          barWidth: 8,
+          value,
+          type: 'horizontal',
+          offsetX: 5,
+          offsetY: height > 58 ? 62 : 48,
+          opacity: 255,
+        };
+        return { imageBuffer: Buffer.from(graphics.bar(options)).toString('base64') };
       },
     },
     frozen_direct: {

--- a/src/feedbacks.js
+++ b/src/feedbacks.js
@@ -208,6 +208,15 @@ export const getFeedbacks = (instance) => {
       options: [
         { type: 'dropdown', label: 'Screen', id: 'screenId', default: screenListDropDown[0]?.id ?? null, choices: screenListDropDown },
         { type: 'colorpicker', label: 'Bar color', id: 'barColor', default: combineRgb(0, 200, 0), returnType: 'number' },
+        {
+          type: 'number',
+          label: 'Bar thickness (px)',
+          id: 'barWidth',
+          default: 18,
+          min: 4,
+          max: 48,
+          tooltip: 'How tall the bar is. Larger = chunkier / more obvious.',
+        },
       ],
       callback: (feedback) => {
         const s = instance.enhancedState?.screens[feedback.options.screenId];
@@ -215,16 +224,18 @@ export const getFeedbacks = (instance) => {
         const barColor = Number(feedback.options.barColor);
         const width = feedback.image?.width ?? 72;
         const height = feedback.image?.height ?? 72;
+        const barWidth = Math.max(4, Math.min(48, Number(feedback.options.barWidth) || 18));
         const options = {
           width,
           height,
           colors: [{ size: 100, color: barColor, background: barColor, backgroundOpacity: 64 }],
-          barLength: width - 10,
-          barWidth: 8,
+          barLength: width - 8,
+          barWidth,
           value,
           type: 'horizontal',
-          offsetX: 5,
-          offsetY: height > 58 ? 62 : 48,
+          offsetX: 4,
+          // Sit the (thicker) bar near the bottom of the button.
+          offsetY: Math.max(0, height - barWidth - 4),
           opacity: 255,
         };
         return { imageBuffer: Buffer.from(graphics.bar(options)).toString('base64') };

--- a/src/main.js
+++ b/src/main.js
@@ -124,7 +124,7 @@ class ModuleInstance extends InstanceBase {
     this.enhancedState.screens[screenId][property] = value;
     const prefix = `screen_${screenId + 1}`;
     const varMap = {
-      brightness: { key: `${prefix}_brightness`, val: value, feedbacks: ['brightness_match'] },
+      brightness: { key: `${prefix}_brightness`, val: value, feedbacks: ['brightness_match', 'brightness_bar'] },
       frozen: { key: `${prefix}_frozen`, val: value ? 'On' : 'Off', feedbacks: ['frozen_direct'] },
       ftb: { key: `${prefix}_ftb`, val: value ? 'On' : 'Off', feedbacks: ['ftb_direct'] },
       bkg: { key: `${prefix}_bkg`, val: value ? 'On' : 'Off', feedbacks: ['bkg_direct'] },

--- a/src/presets.js
+++ b/src/presets.js
@@ -859,7 +859,11 @@ const getDirectScreenPresets = (instance) => {
           {
             down: [
               { actionId: 'set_brightness', options: { screenId, brightness: String(pct) } },
-              { actionId: 'save_brightness', options: { screenId } },
+              // 100 ms wait so the splicer has time to apply the new
+              // brightness before we tell it to persist that value to the
+              // receiving card. Matches the delay that proved reliable in
+              // field testing.
+              { actionId: 'save_brightness', options: { screenId }, delay: 100 },
             ],
             up: [],
           },

--- a/src/presets.js
+++ b/src/presets.js
@@ -835,7 +835,7 @@ const getDirectScreenPresets = (instance) => {
       type: 'button',
       category: 'Brightness',
       name: `${name} Brightness +`,
-      style: { ...baseStyle, text: `${name}\nBright +` },
+      style: { ...baseStyle, text: `$(${MODULE_NAME}:screenId_${screenId})\nBright +` },
       steps: [{ down: [{ actionId: 'brightness_add_direct', options: { screenId } }], up: [] }],
       feedbacks: [],
     };
@@ -843,7 +843,7 @@ const getDirectScreenPresets = (instance) => {
       type: 'button',
       category: 'Brightness',
       name: `${name} Brightness -`,
-      style: { ...baseStyle, text: `${name}\nBright -` },
+      style: { ...baseStyle, text: `$(${MODULE_NAME}:screenId_${screenId})\nBright -` },
       steps: [{ down: [{ actionId: 'brightness_minus_direct', options: { screenId } }], up: [] }],
       feedbacks: [],
     };
@@ -854,7 +854,7 @@ const getDirectScreenPresets = (instance) => {
         type: 'button',
         category: 'Brightness',
         name: `${name} Brightness ${pct}%`,
-        style: { ...baseStyle, text: `${name}\n${pct}%` },
+        style: { ...baseStyle, text: `$(${MODULE_NAME}:screenId_${screenId})\n${pct}%` },
         steps: [
           {
             down: [
@@ -879,7 +879,7 @@ const getDirectScreenPresets = (instance) => {
       type: 'button',
       category: 'Per-Screen Direct',
       name: `${name} Freeze`,
-      style: { ...baseStyle, text: `${name}\nFreeze` },
+      style: { ...baseStyle, text: `$(${MODULE_NAME}:screenId_${screenId})\nFreeze` },
       steps: [
         { down: [{ actionId: 'freeze_direct', options: { screenId, state: 1 } }], up: [] },
         { down: [{ actionId: 'freeze_direct', options: { screenId, state: 0 } }], up: [] },
@@ -894,7 +894,7 @@ const getDirectScreenPresets = (instance) => {
       type: 'button',
       category: 'Per-Screen Direct',
       name: `${name} FTB`,
-      style: { ...baseStyle, text: `${name}\nFTB` },
+      style: { ...baseStyle, text: `$(${MODULE_NAME}:screenId_${screenId})\nFTB` },
       steps: [
         { down: [{ actionId: 'ftb_direct', options: { screenId, state: 1 } }], up: [] },
         { down: [{ actionId: 'ftb_direct', options: { screenId, state: 0 } }], up: [] },
@@ -909,7 +909,7 @@ const getDirectScreenPresets = (instance) => {
       type: 'button',
       category: 'Per-Screen Direct',
       name: `${name} BKG`,
-      style: { ...baseStyle, text: `${name}\nBKG` },
+      style: { ...baseStyle, text: `$(${MODULE_NAME}:screenId_${screenId})\nBKG` },
       steps: [
         { down: [{ actionId: 'bkg_direct', options: { screenId, state: 1 } }], up: [] },
         { down: [{ actionId: 'bkg_direct', options: { screenId, state: 0 } }], up: [] },
@@ -924,7 +924,7 @@ const getDirectScreenPresets = (instance) => {
       type: 'button',
       category: 'Per-Screen Direct',
       name: `${name} OSD Text`,
-      style: { ...baseStyle, text: `${name}\nOSD Text` },
+      style: { ...baseStyle, text: `$(${MODULE_NAME}:screenId_${screenId})\nOSD Text` },
       steps: [
         { down: [{ actionId: 'osd_direct', options: { screenId, osdType: 'text', state: 1 } }], up: [] },
         { down: [{ actionId: 'osd_direct', options: { screenId, osdType: 'text', state: 0 } }], up: [] },
@@ -939,7 +939,7 @@ const getDirectScreenPresets = (instance) => {
       type: 'button',
       category: 'Per-Screen Direct',
       name: `${name} OSD Image`,
-      style: { ...baseStyle, text: `${name}\nOSD Img` },
+      style: { ...baseStyle, text: `$(${MODULE_NAME}:screenId_${screenId})\nOSD Img` },
       steps: [
         { down: [{ actionId: 'osd_direct', options: { screenId, osdType: 'image', state: 1 } }], up: [] },
         { down: [{ actionId: 'osd_direct', options: { screenId, osdType: 'image', state: 0 } }], up: [] },
@@ -956,7 +956,7 @@ const getDirectScreenPresets = (instance) => {
       type: 'button',
       category: 'Per-Screen Direct',
       name: `${name} Test Pattern`,
-      style: { ...baseStyle, text: `${name}\nTest` },
+      style: { ...baseStyle, text: `$(${MODULE_NAME}:screenId_${screenId})\nTest` },
       steps: [
         {
           down: [
@@ -983,7 +983,7 @@ const getDirectScreenPresets = (instance) => {
       type: 'button',
       category: 'Per-Screen Direct',
       name: `${name} PGM/PVW`,
-      style: { ...baseStyle, text: `${name}\nPGM/PVW`, size: '14' },
+      style: { ...baseStyle, text: `$(${MODULE_NAME}:screenId_${screenId})\nPGM/PVW`, size: '14' },
       steps: [
         {
           down: [
@@ -1004,12 +1004,12 @@ const getDirectScreenPresets = (instance) => {
         {
           feedbackId: 'pgm_pvw_switch',
           options: { type: PGM_PVW_TYPE.PGM },
-          style: { bgcolor: GREEN, color: BLACK, text: `${name}\nPGM` },
+          style: { bgcolor: GREEN, color: BLACK, text: `$(${MODULE_NAME}:screenId_${screenId})\nPGM` },
         },
         {
           feedbackId: 'pgm_pvw_switch',
           options: { type: PGM_PVW_TYPE.PVW },
-          style: { bgcolor: RED, color: BLACK, text: `${name}\nPVW` },
+          style: { bgcolor: RED, color: BLACK, text: `$(${MODULE_NAME}:screenId_${screenId})\nPVW` },
         },
       ],
     };
@@ -1019,7 +1019,7 @@ const getDirectScreenPresets = (instance) => {
       type: 'button',
       category: 'Per-Screen Direct',
       name: `${name} Take`,
-      style: { ...baseStyle, text: `${name}\nTake` },
+      style: { ...baseStyle, text: `$(${MODULE_NAME}:screenId_${screenId})\nTake` },
       steps: [
         {
           down: [

--- a/src/presets.js
+++ b/src/presets.js
@@ -1,6 +1,13 @@
 import { combineRgb } from '@companion-module/base';
 import { MODULE_NAME, PGM_PVW_TYPE, TEST_PATTERN_TYPE } from '../utils/constant.js';
 
+const BLACK = combineRgb(0, 0, 0);
+const WHITE = combineRgb(255, 255, 255);
+const GREEN = combineRgb(0, 255, 0);
+const RED = combineRgb(255, 0, 0);
+const BLUE = combineRgb(0, 0, 255);
+const DARK_GREEN = combineRgb(0, 200, 0);
+
 /** 屏幕、图层、场景预设 */
 const getSLPPresets = (screenList) => {
   /** 选中屏幕 */
@@ -807,6 +814,251 @@ const getSourceListPresets = (instance) => {
   return sourceList;
 };
 
+/**
+ * Per-screen direct-control presets. One button per screen for each direct
+ * action (brightness, freeze, FTB, BKG, OSD text, OSD image, test pattern,
+ * PGM/PVW, Take). No select_screen prerequisite for the toggles that have a
+ * matching direct action; PGM/PVW, Take, and test pattern still funnel
+ * through select_screen since there is no `*_direct` action for those.
+ */
+const getDirectScreenPresets = (instance) => {
+  const out = {};
+  const brightnessLevels = [100, 75, 50, 25, 0];
+
+  instance.screenList?.forEach((screen) => {
+    const { name, screenId } = screen;
+    const baseStyle = { size: 'auto', color: WHITE, bgcolor: BLACK };
+
+    // ---- Brightness +/- ----
+    out[`direct_bright_up_${screenId}`] = {
+      type: 'button',
+      category: 'Brightness',
+      name: `${name} Brightness +`,
+      style: { ...baseStyle, text: `${name}\nBright +` },
+      steps: [{ down: [{ actionId: 'brightness_add_direct', options: { screenId } }], up: [] }],
+      feedbacks: [],
+    };
+    out[`direct_bright_down_${screenId}`] = {
+      type: 'button',
+      category: 'Brightness',
+      name: `${name} Brightness -`,
+      style: { ...baseStyle, text: `${name}\nBright -` },
+      steps: [{ down: [{ actionId: 'brightness_minus_direct', options: { screenId } }], up: [] }],
+      feedbacks: [],
+    };
+
+    // ---- Brightness fixed levels (with brightness_match feedback) ----
+    brightnessLevels.forEach((pct) => {
+      out[`set_bright_${screenId}_${pct}`] = {
+        type: 'button',
+        category: 'Brightness',
+        name: `${name} Brightness ${pct}%`,
+        style: { ...baseStyle, text: `${name}\n${pct}%` },
+        steps: [
+          {
+            down: [
+              { actionId: 'set_brightness', options: { screenId, brightness: String(pct) } },
+              { actionId: 'save_brightness', options: { screenId } },
+            ],
+            up: [],
+          },
+        ],
+        feedbacks: [
+          {
+            feedbackId: 'brightness_match',
+            options: { screenId, value: pct },
+            style: { bgcolor: DARK_GREEN, color: WHITE },
+          },
+        ],
+      };
+    });
+
+    // ---- Freeze toggle ----
+    out[`direct_freeze_${screenId}`] = {
+      type: 'button',
+      category: 'Per-Screen Direct',
+      name: `${name} Freeze`,
+      style: { ...baseStyle, text: `${name}\nFreeze` },
+      steps: [
+        { down: [{ actionId: 'freeze_direct', options: { screenId, state: 1 } }], up: [] },
+        { down: [{ actionId: 'freeze_direct', options: { screenId, state: 0 } }], up: [] },
+      ],
+      feedbacks: [
+        { feedbackId: 'frozen_direct', options: { screenId }, style: { bgcolor: BLUE, color: WHITE } },
+      ],
+    };
+
+    // ---- FTB toggle ----
+    out[`direct_ftb_${screenId}`] = {
+      type: 'button',
+      category: 'Per-Screen Direct',
+      name: `${name} FTB`,
+      style: { ...baseStyle, text: `${name}\nFTB` },
+      steps: [
+        { down: [{ actionId: 'ftb_direct', options: { screenId, state: 1 } }], up: [] },
+        { down: [{ actionId: 'ftb_direct', options: { screenId, state: 0 } }], up: [] },
+      ],
+      feedbacks: [
+        { feedbackId: 'ftb_direct', options: { screenId }, style: { bgcolor: RED, color: WHITE } },
+      ],
+    };
+
+    // ---- BKG toggle ----
+    out[`direct_bkg_${screenId}`] = {
+      type: 'button',
+      category: 'Per-Screen Direct',
+      name: `${name} BKG`,
+      style: { ...baseStyle, text: `${name}\nBKG` },
+      steps: [
+        { down: [{ actionId: 'bkg_direct', options: { screenId, state: 1 } }], up: [] },
+        { down: [{ actionId: 'bkg_direct', options: { screenId, state: 0 } }], up: [] },
+      ],
+      feedbacks: [
+        { feedbackId: 'bkg_direct', options: { screenId }, style: { bgcolor: GREEN, color: BLACK } },
+      ],
+    };
+
+    // ---- OSD Text toggle ----
+    out[`direct_osd_text_${screenId}`] = {
+      type: 'button',
+      category: 'Per-Screen Direct',
+      name: `${name} OSD Text`,
+      style: { ...baseStyle, text: `${name}\nOSD Text` },
+      steps: [
+        { down: [{ actionId: 'osd_direct', options: { screenId, osdType: 'text', state: 1 } }], up: [] },
+        { down: [{ actionId: 'osd_direct', options: { screenId, osdType: 'text', state: 0 } }], up: [] },
+      ],
+      feedbacks: [
+        { feedbackId: 'osd_text_direct', options: { screenId }, style: { bgcolor: GREEN, color: BLACK } },
+      ],
+    };
+
+    // ---- OSD Image toggle ----
+    out[`direct_osd_image_${screenId}`] = {
+      type: 'button',
+      category: 'Per-Screen Direct',
+      name: `${name} OSD Image`,
+      style: { ...baseStyle, text: `${name}\nOSD Img` },
+      steps: [
+        { down: [{ actionId: 'osd_direct', options: { screenId, osdType: 'image', state: 1 } }], up: [] },
+        { down: [{ actionId: 'osd_direct', options: { screenId, osdType: 'image', state: 0 } }], up: [] },
+      ],
+      feedbacks: [
+        { feedbackId: 'osd_image_direct', options: { screenId }, style: { bgcolor: GREEN, color: BLACK } },
+      ],
+    };
+
+    // ---- Test Pattern toggle ----
+    // No test_pattern_direct uses test_pattern_switch with select_screen,
+    // matching the pattern used in the pre-split working branch.
+    out[`direct_test_${screenId}`] = {
+      type: 'button',
+      category: 'Per-Screen Direct',
+      name: `${name} Test Pattern`,
+      style: { ...baseStyle, text: `${name}\nTest` },
+      steps: [
+        {
+          down: [
+            { actionId: 'select_screen', options: { screenId, enable: 1 } },
+            { actionId: 'test_pattern_switch', options: { testPattern: TEST_PATTERN_TYPE.OPEN } },
+          ],
+          up: [],
+        },
+        {
+          down: [
+            { actionId: 'select_screen', options: { screenId, enable: 1 } },
+            { actionId: 'test_pattern_switch', options: { testPattern: TEST_PATTERN_TYPE.CLOSE } },
+          ],
+          up: [],
+        },
+      ],
+      feedbacks: [
+        { feedbackId: 'test_pattern_direct', options: { screenId }, style: { bgcolor: GREEN, color: BLACK } },
+      ],
+    };
+
+    // ---- Per-screen PGM/PVW (select-then-act, no direct action exists) ----
+    out[`direct_pgm_pvw_${screenId}`] = {
+      type: 'button',
+      category: 'Per-Screen Direct',
+      name: `${name} PGM/PVW`,
+      style: { ...baseStyle, text: `${name}\nPGM/PVW`, size: '14' },
+      steps: [
+        {
+          down: [
+            { actionId: 'select_screen', options: { screenId, enable: 1 } },
+            { actionId: 'pgm_pvw_switch', options: { enNonTime: 0 } },
+          ],
+          up: [],
+        },
+        {
+          down: [
+            { actionId: 'select_screen', options: { screenId, enable: 1 } },
+            { actionId: 'pgm_pvw_switch', options: { enNonTime: 1 } },
+          ],
+          up: [],
+        },
+      ],
+      feedbacks: [
+        {
+          feedbackId: 'pgm_pvw_switch',
+          options: { type: PGM_PVW_TYPE.PGM },
+          style: { bgcolor: GREEN, color: BLACK, text: `${name}\nPGM` },
+        },
+        {
+          feedbackId: 'pgm_pvw_switch',
+          options: { type: PGM_PVW_TYPE.PVW },
+          style: { bgcolor: RED, color: BLACK, text: `${name}\nPVW` },
+        },
+      ],
+    };
+
+    // ---- Per-screen Take ----
+    out[`direct_take_${screenId}`] = {
+      type: 'button',
+      category: 'Per-Screen Direct',
+      name: `${name} Take`,
+      style: { ...baseStyle, text: `${name}\nTake` },
+      steps: [
+        {
+          down: [
+            { actionId: 'select_screen', options: { screenId, enable: 1 } },
+            { actionId: 'take_switch', options: { manualPlay: 1 } },
+          ],
+          up: [],
+        },
+        {
+          down: [
+            { actionId: 'select_screen', options: { screenId, enable: 1 } },
+            { actionId: 'take_switch', options: { manualPlay: 0 } },
+          ],
+          up: [],
+        },
+      ],
+      feedbacks: [
+        { feedbackId: 'pvw_take_selected', style: { bgcolor: GREEN, color: BLACK } },
+      ],
+    };
+  });
+
+  return out;
+};
+
+/** Global blackout preset (wraps the W0700 blackout action). */
+const getGlobalBlackoutPreset = () => ({
+  blackout_global: {
+    type: 'button',
+    category: 'Display',
+    name: 'Blackout',
+    style: { text: 'BLACKOUT', size: 'auto', color: WHITE, bgcolor: BLACK },
+    steps: [
+      { down: [{ actionId: 'blackout', options: { state: 1 } }], up: [] },
+      { down: [{ actionId: 'blackout', options: { state: 0 } }], up: [] },
+    ],
+    feedbacks: [],
+  },
+});
+
 export const getPresetDefinitions = function (instance) {
   // instance.log('info', JSON.stringify(instance.screenList));
   // instance.log('info', JSON.stringify(instance.sourceList));
@@ -818,5 +1070,7 @@ export const getPresetDefinitions = function (instance) {
     ...getPresetCollectionsPresets(instance),
     ...getSourceListPresets(instance),
     ...applyScreenPreset(),
+    ...getDirectScreenPresets(instance),
+    ...getGlobalBlackoutPreset(),
   };
 };

--- a/src/presets.js
+++ b/src/presets.js
@@ -1064,6 +1064,51 @@ const getGlobalBlackoutPreset = () => ({
   },
 });
 
+/**
+ * One status-button preset per real input connector. The set of connectors
+ * is derived from `inputSignalState` keys — populated by the optional input
+ * signal polling feature (separate PR #41). Each preset has no press action
+ * (the button is informational) and uses the `input_signal` feedback to
+ * turn green when iSignal=1.
+ *
+ * Gated on the inputSignalPolling toggle so this generator returns {} when
+ * the feature is off, when polling hasn't returned any data yet, or when
+ * the input_signal feedback isn't registered. That keeps this branch
+ * order-independent vs #41: if #41 isn't merged yet, no presets are
+ * generated and nothing breaks.
+ */
+const getInputSignalPresets = (instance) => {
+  if (!instance.config?.inputSignalPolling) return {};
+  const out = {};
+  const keys = Object.keys(instance.inputSignalState ?? {}).sort();
+  for (const inputKey of keys) {
+    const m = inputKey.match(/^input_(\d+)_(\d+)$/);
+    if (!m) continue;
+    const slot = m[1];
+    const conn = m[2];
+    out[`input_signal_${slot}_${conn}`] = {
+      type: 'button',
+      category: 'Input Signal',
+      name: `Input ${slot}-${conn} Signal`,
+      style: {
+        text: `In ${slot}-${conn}\n$(${MODULE_NAME}:${inputKey}_signal)`,
+        size: 'auto',
+        color: WHITE,
+        bgcolor: BLACK,
+      },
+      steps: [{ down: [], up: [] }],
+      feedbacks: [
+        {
+          feedbackId: 'input_signal',
+          options: { inputKey },
+          style: { bgcolor: GREEN, color: BLACK },
+        },
+      ],
+    };
+  }
+  return out;
+};
+
 export const getPresetDefinitions = function (instance) {
   // instance.log('info', JSON.stringify(instance.screenList));
   // instance.log('info', JSON.stringify(instance.sourceList));
@@ -1077,5 +1122,6 @@ export const getPresetDefinitions = function (instance) {
     ...applyScreenPreset(),
     ...getDirectScreenPresets(instance),
     ...getGlobalBlackoutPreset(),
+    ...getInputSignalPresets(instance),
   };
 };

--- a/src/presets.js
+++ b/src/presets.js
@@ -823,7 +823,8 @@ const getSourceListPresets = (instance) => {
  */
 const getDirectScreenPresets = (instance) => {
   const out = {};
-  const brightnessLevels = [100, 75, 50, 25, 0];
+  // 5% steps from 100 down to 0, matching the pre-split working branch.
+  const brightnessLevels = [100, 95, 90, 85, 80, 75, 70, 65, 60, 55, 50, 45, 40, 35, 30, 25, 20, 15, 10, 5, 0];
 
   instance.screenList?.forEach((screen) => {
     const { name, screenId } = screen;

--- a/src/presets.js
+++ b/src/presets.js
@@ -848,6 +848,22 @@ const getDirectScreenPresets = (instance) => {
       feedbacks: [],
     };
 
+    // ---- Brightness bar readout (graphical bar + numeric value) ----
+    // Info-only button: text shows the screen name and the live brightness
+    // variable, the brightness_bar feedback draws a horizontal progress bar
+    // along the bottom. Mirrors the Resolume progress-bar preset pattern.
+    out[`bright_bar_${screenId}`] = {
+      type: 'button',
+      category: 'Brightness',
+      name: `${name} Brightness Bar`,
+      style: {
+        ...baseStyle,
+        text: `$(${MODULE_NAME}:screenId_${screenId})\n$(${MODULE_NAME}:screen_${screenId + 1}_brightness)%`,
+      },
+      steps: [{ down: [], up: [] }],
+      feedbacks: [{ feedbackId: 'brightness_bar', options: { screenId, barColor: DARK_GREEN } }],
+    };
+
     // ---- Brightness fixed levels (with brightness_match feedback) ----
     brightnessLevels.forEach((pct) => {
       out[`set_bright_${screenId}_${pct}`] = {

--- a/yarn.lock
+++ b/yarn.lock
@@ -480,6 +480,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/pngjs@npm:^6.0.1":
+  version: 6.0.5
+  resolution: "@types/pngjs@npm:6.0.5"
+  dependencies:
+    "@types/node": "npm:*"
+  checksum: 10c0/11979d0690e774046d3a1e8cfc613a6b53a613909d81c93831cf253800e93ba1a2d47950979b523aebd4fc023351b644d7f4aa2dfcc027c70816a2968420e7da
+  languageName: node
+  linkType: hard
+
 "@types/ps-tree@npm:^1.1.6":
   version: 1.1.6
   resolution: "@types/ps-tree@npm:1.1.6"
@@ -1251,6 +1260,16 @@ __metadata:
   version: 2.20.3
   resolution: "commander@npm:2.20.3"
   checksum: 10c0/74c781a5248c2402a0a3e966a0a2bba3c054aad144f5c023364be83265e796b20565aa9feff624132ff629aa64e16999fa40a743c10c12f7c61e96a794b99288
+  languageName: node
+  linkType: hard
+
+"companion-module-utils@npm:^0.4.0":
+  version: 0.4.0
+  resolution: "companion-module-utils@npm:0.4.0"
+  dependencies:
+    "@types/pngjs": "npm:^6.0.1"
+    pngjs: "npm:^7.0.0"
+  checksum: 10c0/218f9f8d63d10affdee15a00c6235fe170ca1d0bdb21bf238adf52ef78859fe2495d5acb3c6b208de203b405341599ea16b83bbb0eeb0cc1073a57319d2923ee
   languageName: node
   linkType: hard
 
@@ -2848,6 +2867,7 @@ __metadata:
     "@companion-module/base": "npm:~1.5.1"
     "@companion-module/tools": "npm:^1.5.2"
     axios: "npm:^1.15.2"
+    companion-module-utils: "npm:^0.4.0"
     eslint: "npm:^9.30.1"
     eslint-config-prettier: "npm:^10.1.5"
     eslint-plugin-prettier: "npm:^5.5.1"
@@ -3100,6 +3120,13 @@ __metadata:
   dependencies:
     find-up: "npm:^4.0.0"
   checksum: 10c0/c56bda7769e04907a88423feb320babaed0711af8c436ce3e56763ab1021ba107c7b0cafb11cde7529f669cfc22bffcaebffb573645cbd63842ea9fb17cd7728
+  languageName: node
+  linkType: hard
+
+"pngjs@npm:^7.0.0":
+  version: 7.0.0
+  resolution: "pngjs@npm:7.0.0"
+  checksum: 10c0/0d4c7a0fd476a9c33df7d0a2a73e1d56537628a668841f6995c2bca070cf30819f9254a64363266bc14ef2fee47659dd3b4f2b18eec7ab65143015139f497b38
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

Follow-up to my split series — when I split the original mega-PR into four feature-scoped branches, #39 landed all the per-screen **direct actions and feedbacks**, but I never carried over the **preset wrappers** from my pre-split working branch. Result: operators have all the new direct actions available, but no drag-and-drop preset buttons to expose them, so they end up building every per-screen button by hand. That undermines the whole UX win of #39 (one-click per-screen control instead of `select → change → deselect`). Catching it up here.

Also includes the global blackout preset (wraps the W0700 action from #42).

## What this adds

### Brightness category
Per-screen one-button brightness controls:
- `direct_bright_up_${screenId}` — uses `brightness_add_direct`
- `direct_bright_down_${screenId}` — uses `brightness_minus_direct`
- `set_bright_${screenId}_{100,75,50,25,0}` — fixed levels via `set_brightness` + `save_brightness`, highlighted by `brightness_match` feedback

### Per-Screen Direct category
One-button per-screen toggles, all already-shipped direct actions wired to matching direct feedbacks:
- `direct_freeze_${screenId}` — `freeze_direct` + `frozen_direct` feedback
- `direct_ftb_${screenId}` — `ftb_direct` + `ftb_direct` feedback
- `direct_bkg_${screenId}` — `bkg_direct` + `bkg_direct` feedback
- `direct_osd_text_${screenId}` — `osd_direct` (text) + `osd_text_direct` feedback
- `direct_osd_image_${screenId}` — `osd_direct` (image) + `osd_image_direct` feedback
- `direct_test_${screenId}` — `select_screen` + `test_pattern_switch` + `test_pattern_direct` feedback
- `direct_pgm_pvw_${screenId}` — `select_screen` + `pgm_pvw_switch` + `pgm_pvw_switch` feedback
- `direct_take_${screenId}` — `select_screen` + `take_switch` + `pvw_take_selected` feedback

### Display category
- `blackout_global` — wraps the W0700 `blackout` action

## Dependency note

`save_brightness` and `blackout` are introduced in #42. Until that lands, the `set_bright_*` save step is a no-op and the `blackout_global` button doesn't fire. Everything else works against current main today.

## Regression scope

Strictly additive. No existing presets, actions, feedbacks, or handlers are modified.

## Test plan

- [x] All per-screen direct toggle presets work against live H5
- [x] Brightness level presets set + save correctly (after #42 lands locally)
- [x] `brightness_match` feedback highlights the active level
- [x] Existing global presets (`brightness_add`, `brightness_minus`, etc.) untouched
