### PR TITLE
Make device poll interval configurable (default 1000 ms)

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -191,9 +191,10 @@ class ModuleInstance extends InstanceBase {
     if (this.dataInterval) {
       clearInterval(this.dataInterval);
     }
+    const interval = Math.max(500, Math.min(30000, Number(this.config.pollInterval) || 1000));
     this.dataInterval = setInterval(() => {
       this.getAllData();
-    }, 10000);
+    }, interval);
   }
 
   async init(config) {
@@ -351,6 +352,17 @@ class ModuleInstance extends InstanceBase {
         width: 6,
         default: '6000',
         regex: Regex.PORT,
+      },
+      {
+        type: 'number',
+        id: 'pollInterval',
+        label: 'Poll Interval (ms)',
+        width: 6,
+        min: 500,
+        max: 30000,
+        default: 1000,
+        tooltip:
+          'How often to poll the device for state updates (500-30000 ms). Lower values give snappier feedback at the cost of more UDP traffic. Default 1000 ms (was hardcoded 10000 ms).',
       },
       {
         type: 'static-text',


### PR DESCRIPTION
## Summary

The device poll interval in `handleGetAllData` was hardcoded at 10000 ms. For live event work that's noticeably slow — feedback for a brightness change, freeze toggle, or input switch can take up to 10 seconds to reflect in Companion.

This makes the interval configurable.

## What changes

- New `Poll Interval (ms)` config field. Range 500-30000, default **1000**.
- `handleGetAllData()` reads `this.config.pollInterval` (clamped to the same range as a safety net) instead of the hardcoded `10000`.

## Why default 1 second

Existing live-control modules in the Companion ecosystem (analog/SDI matrices, switchers, lighting consoles) settle around 500-1000 ms polling for feedback responsiveness. 1 second is the right default for operators who haven't tuned anything; users who care about UDP load on the device can dial it up from there.

## Regression scope

- Anyone who didn't have a `pollInterval` set (i.e. all current users) falls back to the new default (1000 ms instead of 10000 ms). That's a behavior change in volume of polling, but only in the direction of more responsive feedback.
- No new API surface, no new dependencies.

## Test plan

- [x] Set 500 ms in config, observe ~2x faster feedback updates
- [x] Set 30000 ms, observe slower updates with reduced UDP traffic
- [x] Leave default, verify 1 second cadence
- [x] No restart needed when changing the field
