### PR TITLE
Preserve layers/presets/details across R0400 poll cycles (fix preset flicker)

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -655,7 +655,25 @@ class ModuleInstance extends InstanceBase {
   }
   /** 处理屏幕列表 */
   dealScreenList(data) {
-    this.screenList = data.screens;
+    // Preserve existing layers/presets/details on each screen while replacing
+    // the rest of the screen record. R0400 carries only top-level screen
+    // fields (screenId, name, etc.); layers come from R0500, presets from
+    // R0600, and details from R0401. If we wipe screenList wholesale on
+    // every R0400, the layer/preset/screen-detail presets briefly vanish
+    // during each poll cycle until the dependent responses come back. The
+    // window is small at low poll rates but visible to operators on a slow
+    // network or once polling speeds up.
+    const prev = this.screenList ?? [];
+    const merged = (data.screens ?? []).map((newScreen) => {
+      const existing = prev.find((s) => s.screenId === newScreen.screenId);
+      return {
+        ...newScreen,
+        layers: newScreen.layers ?? existing?.layers ?? [],
+        presets: newScreen.presets ?? existing?.presets ?? [],
+        details: newScreen.details ?? existing?.details,
+      };
+    });
+    this.screenList = merged;
     data.screens.forEach((screen) => {
       getLayerList(this, screen.screenId);
       getPresetList(this, screen.screenId);


### PR DESCRIPTION
## Summary

Real bug, surfaced on a live H5 during a show preview today (visible in #46 testing): the layer and preset recall presets briefly disappear from Companion every poll cycle. At the previous hardcoded 10000 ms poll rate the window was tiny and went unnoticed. On a slow network it can show up at any rate.

## Root cause

`dealScreenList(data)` replaces `this.screenList` wholesale on every R0400 (`get_screen_list`) response. R0400 only carries top-level screen fields (`screenId`, `name`, `screenType`, etc.). Layers come from R0500, presets from R0600, and screen details from R0401, each fired separately per-screen after R0400 lands.

So in the window between R0400 arriving and the dependent R0500 / R0600 / R0401 responses coming back, `screenList` contains brand-new screen entries with no `layers`, no `presets`, and no `details`. Every `updateAll()` in that window emits layer + preset + screen-detail presets from `getSLPPresets()` as empty arrays — they vanish until the next responses overwrite the entries.

## Fix

Merge the new R0400 screen data on top of the existing screen entries, preserving previously-fetched `layers`, `presets`, and `details` until the dependent fetches refresh them. The dependent requests still fire as before, so fresh data flows in within one round trip and overwrites the preserved values.

```js
const merged = (data.screens ?? []).map((newScreen) => {
  const existing = prev.find((s) => s.screenId === newScreen.screenId);
  return {
    ...newScreen,
    layers: newScreen.layers ?? existing?.layers ?? [],
    presets: newScreen.presets ?? existing?.presets ?? [],
    details: newScreen.details ?? existing?.details,
  };
});
```

## Regression scope

Strictly defensive. No behavior change for first-poll-after-connect (no prior data to preserve). No change in what requests fire. The dependent responses still overwrite preserved values within one round trip.

## Test plan

- [x] Reproduce: set poll interval to 1000 ms (or apply #46), observe layer + preset presets flicker out of the button picker every second on upstream main
- [x] Apply this patch: layer + preset presets stay populated continuously
- [x] Confirmed against live H5 splicer with 3 screens, 12 outputs, 8 input cards
- [x] No change in count or timing of R0500 / R0600 / R0401 requests
