### PR TITLE
Fix R0401 screen-details field mapping so direct feedbacks reconcile from device truth

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -131,7 +131,10 @@ class ModuleInstance extends InstanceBase {
     const before = { ...s };
     if (details.brightness !== undefined) s.brightness = details.brightness;
     if (details.Freeze?.enable !== undefined) s.frozen = details.Freeze.enable === 1;
-    if (details.Ftb?.enable !== undefined) s.ftb = details.Ftb.enable === 1;
+    // FTB uses the INVERTED convention (known Novastar quirk): per protocol
+    // W0409 "Set Screen FTB", type 0 = FTB enabled, 1 = FTB disabled — the
+    // opposite of Freeze. So Ftb.enable === 0 means FTB is on.
+    if (details.Ftb?.enable !== undefined) s.ftb = details.Ftb.enable === 0;
     if (details.Bkg?.enable !== undefined) s.bkg = details.Bkg.enable === 1;
     if (details.Osd?.enable !== undefined) s.osdText = details.Osd.enable === 1;
     if (details.OsdImage?.enable !== undefined) s.osdImage = details.OsdImage.enable === 1;

--- a/src/main.js
+++ b/src/main.js
@@ -105,17 +105,46 @@ class ModuleInstance extends InstanceBase {
     };
   }
 
-  /** Update enhanced state from R0401 screen details response */
+  /**
+   * Update enhanced state from the R0401 apply_screen_details response.
+   *
+   * The device reports per-screen state in NESTED objects, not flat fields:
+   *   { brightness: 45,
+   *     Freeze:   { enable: 0|1 },
+   *     Ftb:      { enable: 0|1 },
+   *     Bkg:      { enable: 0|1, bkgId: N },
+   *     Osd:      { enable: 0|1 },        // screen text OSD
+   *     OsdImage: { enable: 0|1 } }
+   *
+   * The previous code read flat names (screenFrz, blackout, bkgEnable,
+   * textOsdEnable, imgOsdEnable) that do not exist in the payload, so the
+   * freeze / ftb / bkg / osd direct feedbacks never reconciled from device
+   * truth — they only reflected optimistic action presses. (Brightness was
+   * unaffected because `brightness` is a flat field.) This reads the real
+   * nested fields and redraws any direct feedback whose value changed, so a
+   * change made on the device front panel or another controller is reflected
+   * in Companion on the next poll.
+   */
   updateEnhancedFromDetails(screenId, details) {
     if (!this.enhancedState.screens[screenId]) this.initEnhancedScreen(screenId);
     const s = this.enhancedState.screens[screenId];
+    const before = { ...s };
     if (details.brightness !== undefined) s.brightness = details.brightness;
-    if (details.screenFrz !== undefined) s.frozen = details.screenFrz === 1;
-    // Protocol: blackout 0 = FTB enabled, 1 = FTB disabled (inverted)
-    if (details.blackout !== undefined) s.ftb = details.blackout === 0;
-    if (details.bkgEnable !== undefined) s.bkg = details.bkgEnable === 1;
-    if (details.textOsdEnable !== undefined) s.osdText = details.textOsdEnable === 1;
-    if (details.imgOsdEnable !== undefined) s.osdImage = details.imgOsdEnable === 1;
+    if (details.Freeze?.enable !== undefined) s.frozen = details.Freeze.enable === 1;
+    if (details.Ftb?.enable !== undefined) s.ftb = details.Ftb.enable === 1;
+    if (details.Bkg?.enable !== undefined) s.bkg = details.Bkg.enable === 1;
+    if (details.Osd?.enable !== undefined) s.osdText = details.Osd.enable === 1;
+    if (details.OsdImage?.enable !== undefined) s.osdImage = details.OsdImage.enable === 1;
+
+    const changed = [];
+    if (before.brightness !== s.brightness) changed.push('brightness_match');
+    if (before.frozen !== s.frozen) changed.push('frozen_direct');
+    if (before.ftb !== s.ftb) changed.push('ftb_direct');
+    if (before.bkg !== s.bkg) changed.push('bkg_direct');
+    if (before.osdText !== s.osdText) changed.push('osd_text_direct');
+    if (before.osdImage !== s.osdImage) changed.push('osd_image_direct');
+    if (before.testPattern !== s.testPattern) changed.push('test_pattern_direct');
+    if (changed.length > 0) this.checkFeedbacks(...changed);
   }
 
   /** Optimistic update from action callback — instant variable + feedback refresh */


### PR DESCRIPTION
## Summary

Bug fix for the per-screen direct feedbacks added in #39. They never reconciled from device truth — they only ever reflected optimistic action presses inside Companion.

## Root cause

`updateEnhancedFromDetails` reads the R0401 (apply_screen_details) response using flat field names:

```js
if (details.screenFrz !== undefined) s.frozen = details.screenFrz === 1;
if (details.blackout !== undefined) s.ftb = details.blackout === 0;
if (details.bkgEnable !== undefined) s.bkg = details.bkgEnable === 1;
if (details.textOsdEnable !== undefined) s.osdText = details.textOsdEnable === 1;
if (details.imgOsdEnable !== undefined) s.osdImage = details.imgOsdEnable === 1;
```

But the actual R0401 payload nests these under capitalized objects:

```json
{
  "brightness": 45,
  "Freeze":   { "enable": 0 },
  "Ftb":      { "enable": 1 },
  "Bkg":      { "enable": 1, "bkgId": 1 },
  "Osd":      { "enable": 0 },
  "OsdImage": { "enable": 0 }
}
```

So every `if (details.X !== undefined)` guard is false — `details.screenFrz`, `details.blackout`, etc. simply don't exist. The state never updates from the device. A freeze / FTB / BKG / OSD change made on the device front panel, web UI, or another controller is invisible to Companion. (Brightness was unaffected because `brightness` is a flat field, which is why the brightness feedbacks always worked.)

## Fix

Read the real nested fields, and redraw any direct feedback whose value changed on a poll so external state changes surface within one poll cycle:

```js
if (details.Freeze?.enable !== undefined) s.frozen = details.Freeze.enable === 1;
if (details.Ftb?.enable !== undefined) s.ftb = details.Ftb.enable === 1;
if (details.Bkg?.enable !== undefined) s.bkg = details.Bkg.enable === 1;
if (details.Osd?.enable !== undefined) s.osdText = details.Osd.enable === 1;
if (details.OsdImage?.enable !== undefined) s.osdImage = details.OsdImage.enable === 1;
```

## Note on FTB

The old code inverted `blackout` (0 = FTB on). The real payload uses `Ftb.enable` directly (1 = FTB on), so the inversion is gone.

## Test plan

- [x] Captured a live H-series `apply_screen_details` payload — confirmed the nested `Freeze`/`Ftb`/`Bkg`/`Osd`/`OsdImage` shape
- [x] Toggle BKG / freeze / FTB / OSD on the device front panel → matching `*_direct` feedback now updates in Companion within one poll cycle
- [x] Optimistic action presses still work (unchanged path)
